### PR TITLE
Fix missing import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools.package-data]
 "*" = ["*.json"]
+
 ["py.typed"]
 
 [tool.pydocstyle]

--- a/radicalpy/__init__.py
+++ b/radicalpy/__init__.py
@@ -7,6 +7,7 @@ from . import (
     classical,
     data,
     estimations,
+    experiments,
     kinetics,
     relaxation,
     shared,


### PR DESCRIPTION
After `import radicalpy`, them module `radicalpy.experiments` was not available because it was not imported in the `__init__.py` in the `radicalpy` dir.