### PR TITLE
Fixed potential bug for Hamiltonian

### DIFF
--- a/examples/cidnp.py
+++ b/examples/cidnp.py
@@ -22,7 +22,7 @@ def main(tmax=5e-6, dt=5e-9, Bmax=20000, dB=100):
     sim = rp.simulation.LiouvilleSimulation([r1, r2])
 
     # Modify the g-factors for both radicals
-    ge = -C.g_e
+    ge = C.g_e
     g1 = 2.0031
     g2 = 2.0031
     r1.radical.magnetogyric_ratio = r1.radical.magnetogyric_ratio / ge * g1

--- a/radicalpy/data_files/constants.json
+++ b/radicalpy/data_files/constants.json
@@ -73,9 +73,9 @@
   },
   "g_e": {
     "name": "electron g-factor",
-    "value": -2.0023193043718,
+    "value": 2.0023193043718,
     "unit": "",
-    "alt_def": "-2(1 + a_e)"
+    "alt_def": "2(1 + a_e)"
   },
   "mu_p": {
     "name": "proton magnetic moment",

--- a/radicalpy/estimations.py
+++ b/radicalpy/estimations.py
@@ -329,7 +329,7 @@ def dipolar_interaction_isotropic(r: float | np.ndarray) -> float | np.ndarray:
     .. _Santabarbara et al. Biochemistry, 44, 6, 2119–2128 (2005):
        https://pubs.acs.org/doi/10.1021/bi048445d
     """
-    conversion = (3 * -C.g_e * C.mu_B * C.mu_0) / (8 * np.pi)
+    conversion = (3 * C.g_e * C.mu_B * C.mu_0) / (8 * np.pi)
     return (-conversion / r**3) * 1000
 
 
@@ -418,8 +418,8 @@ def g_tensor_relaxation_rate(tau_c: float, g1: list, g2: list) -> float:
     .. _Player et al. J. Chem. Phys. 153, 084303 (2020):
        https://doi.org/10.1063/5.0021643
     """
-    g1sum = sum((gi - C.g_e) ** 2 for gi in g1)
-    g2sum = sum((gi - C.g_e) ** 2 for gi in g2)
+    g1sum = sum((gi + C.g_e) ** 2 for gi in g1)
+    g2sum = sum((gi + C.g_e) ** 2 for gi in g2)
     return (g1sum + g2sum) / (9 * tau_c)
 
 
@@ -497,7 +497,7 @@ def k_ST_mixing(Bhalf: float) -> float:
     .. _Steiner et al. Chem. Rev. 89, 1, 51–147 (1989):
        https://doi.org/10.1021/cr00091a003
     """
-    return -C.g_e * (C.mu_B * 1e-3) * Bhalf / C.h
+    return C.g_e * (C.mu_B * 1e-3) * Bhalf / C.h
 
 
 def k_electron_transfer(
@@ -645,7 +645,7 @@ def k_triplet_relaxation(B0: float, tau_c: float, D: float, E: float) -> float:
        https://doi.org/10.1080/00268977400101361
     """
     B0 = utils.mT_to_MHz(B0)
-    nu_0 = (C.g_e * (C.mu_B * 1e-3) * B0) / C.h
+    nu_0 = (-C.g_e * (C.mu_B * 1e-3) * B0) / C.h
     jnu0tc = (2 / 15) * (
         (4 * tau_c) / (1 + 4 * nu_0**2 * tau_c**2) + (tau_c) / (1 + nu_0**2 * tau_c**2)
     )

--- a/radicalpy/simulation.py
+++ b/radicalpy/simulation.py
@@ -515,7 +515,7 @@ class HilbertSimulation:
         SAz = self.spin_operator(0, "z")
         SBz = self.spin_operator(1, "z")
         omega = (2 / 3) * self.radicals[0].gamma_mT * D
-        return omega * (3 * SAz * SBz - SASB)
+        return omega * (3 * SAz @ SBz - SASB)
 
     def dipolar_hamiltonian_3d(self, dipolar_tensor: np.ndarray) -> np.ndarray:
         """Construct the 3D Dipolar Hamiltonian.

--- a/radicalpy/simulation.py
+++ b/radicalpy/simulation.py
@@ -374,13 +374,12 @@ class HilbertSimulation:
         """
         particles = np.array(
             [
-                [self.spin_operator(idx, axis) for axis in "xyz"]
-                for idx in range(len(self.particles))
+                [p.gamma_mT * self.spin_operator(idx, axis) for axis in "xyz"]
+                for idx, p in enumerate(self.particles)
             ]
         )
         rotation = utils.spherical_to_cartesian(theta, phi)
-        omega = B0 * self.radicals[0].gamma_mT
-        return omega * np.einsum("j,ijkl->kl", rotation, particles)
+        return -B0 * np.einsum("j,ijkl->kl", rotation, particles)
 
     def hyperfine_hamiltonian(self, hfc_anisotropy: bool = False) -> np.ndarray:
         """Construct the Hyperfine Hamiltonian.

--- a/radicalpy/utils.py
+++ b/radicalpy/utils.py
@@ -84,7 +84,7 @@ def Gauss_to_MHz(Gauss: float) -> float:
     Returns:
             float: The magnetic flux density converted to MHz.
     """
-    return Gauss / (1e-10 * -C.g_e * C.mu_B / C.h)
+    return Gauss / (1e-10 * C.g_e * C.mu_B / C.h)
 
 
 def Gauss_to_angular_frequency(Gauss: float) -> float:
@@ -97,7 +97,7 @@ def Gauss_to_angular_frequency(Gauss: float) -> float:
             float: The magnetic flux density converted to angular
             frequency (rad/s/T).
     """
-    return Gauss * (C.mu_B / C.hbar * -C.g_e / 1e10)
+    return Gauss * (C.mu_B / C.hbar * C.g_e / 1e10)
 
 
 def Gauss_to_mT(Gauss: float) -> float:
@@ -153,7 +153,7 @@ def MHz_to_Gauss(MHz: float) -> float:
     Returns:
             float: Megahertz (MHz) converted to Gauss (G).
     """
-    return MHz / (1e-10 * -C.g_e * C.mu_B / C.h)
+    return MHz / (1e-10 * C.g_e * C.mu_B / C.h)
 
 
 def MHz_to_mT(MHz: float) -> float:
@@ -165,7 +165,7 @@ def MHz_to_mT(MHz: float) -> float:
     Returns:
             float: Megahertz (MHz) converted to millitesla (mT).
     """
-    return MHz / (1e-9 * -C.g_e * C.mu_B / C.h)
+    return MHz / (1e-9 * C.g_e * C.mu_B / C.h)
 
 
 def angular_frequency_in_MHz(ang_freq: float) -> float:
@@ -189,7 +189,7 @@ def angular_frequency_to_Gauss(ang_freq: float) -> float:
     Returns:
             float: The angular frequency converted to Gauss (G).
     """
-    return ang_freq / (C.mu_B / C.hbar * -C.g_e / 1e10)
+    return ang_freq / (C.mu_B / C.hbar * C.g_e / 1e10)
 
 
 def angular_frequency_to_mT(ang_freq: float) -> float:
@@ -201,7 +201,7 @@ def angular_frequency_to_mT(ang_freq: float) -> float:
     Returns:
             float: The angular frequency converted to millitesla (mT).
     """
-    return ang_freq / (C.mu_B / C.hbar * -C.g_e / 1e9)
+    return ang_freq / (C.mu_B / C.hbar * C.g_e / 1e9)
 
 
 def anisotropy_check(
@@ -323,7 +323,7 @@ def mT_to_MHz(mT: float) -> float:
     Returns:
             float: The magnetic flux density converted to Megahertz (MHz).
     """
-    return mT * (1e-9 * -C.g_e * C.mu_B / C.h)
+    return mT * (1e-9 * C.g_e * C.mu_B / C.h)
 
 
 def mT_to_angular_frequency(mT: float) -> float:
@@ -335,7 +335,7 @@ def mT_to_angular_frequency(mT: float) -> float:
     Returns:
             float: The magnetic flux density converted to angular frequency (rad/s/T).
     """
-    return mT * (C.mu_B / C.hbar * -C.g_e / 1e9)
+    return mT * (C.mu_B / C.hbar * C.g_e / 1e9)
 
 
 def read_trajectory_files(path: Path, scale=1e-10):

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -36,7 +36,7 @@ class ConstantTestCase(unittest.TestCase):
         self.assertEqual(C.mu_N, 5.05078343e-27)
         self.assertEqual(C.mu_e, -9.28476412e-24)
         self.assertEqual(C.a_e, 0.0011596521859)
-        self.assertEqual(C.g_e, -2.0023193043718)
+        self.assertEqual(C.g_e, 2.0023193043718)
         self.assertEqual(C.mu_p, 1.41060671e-26)
         self.assertEqual(C.g_p, 5.5856946893)
         self.assertEqual(C.N_A, 6.0221415e23)


### PR DESCRIPTION
- Fixed potential bug for dipolar coupling
<img width="642" height="310" alt="image" src="https://github.com/user-attachments/assets/9ab1451e-38a4-4b34-b484-fa9c8902b3f3" />

The product of `S1z` and `S2z` should be matrix product rather than element wise product. (If `S1z` and `S2z` are in the form before kronecker product, original code would be fine.)

FYI:

```math
\hat{S}_{1z} \hat{S}_{2z} \ket{s_1s_2} 
:= \left(\hat{S}_{1z}\otimes\hat{1}_{2}\right) \left(\hat{1}_1 \otimes \hat{S}_{2z}\right)  \ket{s_1s_2}
= \left(\hat{1}_{1} \otimes \hat{S}_{2z}\right)  \left(\hat{S}_{1z}\otimes\hat{1}_{2}\right) \ket{s_1s_2}
\neq  \left[\left(\hat{S}_{1z}\otimes\hat{1}_{2}\right) \odot \left(\hat{1}_1 \otimes \hat{S}_{2z}\right)\right]  \ket{s_1s_2}
```

- Zeeman interaction for 3d rotation
<img width="290" height="135" alt="image" src="https://github.com/user-attachments/assets/843a3122-5a33-440e-b06f-10446e9ffcef" />

Original code employed gamma of electron even for nuclei.  
In addition, to keep the consistency to 1d case, `B0` is flipped to `-B0`.

