### PR TITLE
Read hyperfine tensors from orca 6.0.x

### DIFF
--- a/examples/data/NH2_A.out
+++ b/examples/data/NH2_A.out
@@ -1,0 +1,1381 @@
+
+                                 *****************
+                                 * O   R   C   A *
+                                 *****************
+
+                                            #,                                       
+                                            ###                                      
+                                            ####                                     
+                                            #####                                    
+                                            ######                                   
+                                           ########,                                 
+                                     ,,################,,,,,                         
+                               ,,#################################,,                 
+                          ,,##########################################,,             
+                       ,#########################################, ''#####,          
+                    ,#############################################,,   '####,        
+                  ,##################################################,,,,####,       
+                ,###########''''           ''''###############################       
+              ,#####''   ,,,,##########,,,,          '''####'''          '####       
+            ,##' ,,,,###########################,,,                        '##       
+           ' ,,###''''                  '''############,,,                           
+         ,,##''                                '''############,,,,        ,,,,,,###''
+      ,#''                                            '''#######################'''  
+     '                                                          ''''####''''         
+             ,#######,   #######,   ,#######,      ##                                
+            ,#'     '#,  ##    ##  ,#'     '#,    #''#        ,####,   ,####,        
+            ##       ##  ##   ,#'  ##            #'  '#       #'       #'  '#        
+            ##       ##  #######   ##           ,######,      #####,   #    #        
+            '#,     ,#'  ##    ##  '#,     ,#' ,#      #,     #,   #   #,  ,#        
+             '#######'   ##     ##  '#######'  #'      '#     '####' # '####'        
+
+
+
+                #########################################################
+                #                        -***-                          #
+                #          Department of theory and spectroscopy        #
+                #                                                       #
+                #                      Frank Neese                      #
+                #                                                       #
+                #     Directorship, Architecture, Infrastructure        #
+                #                    SHARK, DRIVERS                     #
+                #        Core code/Algorithms in most modules           #
+                #                                                       #
+                #        Max Planck Institute fuer Kohlenforschung      #
+                #                Kaiser Wilhelm Platz 1                 #
+                #                 D-45470 Muelheim/Ruhr                 #
+                #                      Germany                          #
+                #                                                       #
+                #                  All rights reserved                  #
+                #                        -***-                          #
+                #########################################################
+
+
+                         Program Version 6.0.0  -   RELEASE  -
+
+
+ With contributions from (in alphabetic order):
+   Daniel Aravena         : Magnetic Suceptibility
+   Michael Atanasov       : Ab Initio Ligand Field Theory (pilot matlab implementation)
+   Alexander A. Auer      : GIAO ZORA, VPT2 properties, NMR spectrum
+   Ute Becker             : All parallelization in ORCA, NUMFREQ, NUMCALC
+   Giovanni Bistoni       : ED, misc. LED, open-shell LED, HFLD
+   Martin Brehm           : Molecular dynamics
+   Dmytro Bykov           : pre 5.0 version of the SCF Hessian
+   Marcos Casanova-Páez   : Triplet and SCS-CIS(D). UHF-(DLPNO)-IP/EA/STEOM-CCSD. UHF-CVS-IP/STEOM-CCSD
+   Vijay G. Chilkuri      : MRCI spin determinant printing, contributions to CSF-ICE
+   Pauline Colinet        : FMM embedding
+   Dipayan Datta          : RHF DLPNO-CCSD density
+   Achintya Kumar Dutta   : EOM-CC, STEOM-CC
+   Nicolas Foglia         : Exact transition moments, OPA infrastructure, MCD improvements
+   Dmitry Ganyushin       : Spin-Orbit,Spin-Spin,Magnetic field MRCI
+   Miquel Garcia          : C-PCM and meta-GGA Hessian, CCSD/C-PCM, Gaussian charge scheme
+   Tiago L. C. Gouveia    : GS-ROHF, GS-ROCIS
+   Yang Guo               : DLPNO-NEVPT2, F12-NEVPT2, CIM, IAO-localization
+   Andreas Hansen         : Spin unrestricted coupled pair/coupled cluster methods
+   Ingolf Harden          : AUTO-CI MPn and infrastructure 
+   Benjamin Helmich-Paris : MC-RPA, TRAH-(SCF,CASSCF), AVAS, COSX integrals, SCF dyn. polar.
+   Lee Huntington         : MR-EOM, pCC
+   Robert Izsak           : Overlap fitted RIJCOSX, COSX-SCS-MP3, EOM
+   Riya Kayal             : Wick's Theorem for AUTO-CI, AUTO-CI UHF-CCSDT
+   Emily Kempfer          : AUTO-CI, RHF CISDT and CCSDT
+   Christian Kollmar      : KDIIS, OOCD, Brueckner-CCSD(T), CCSD density, CASPT2, CASPT2-K, improved NEVPT2
+   Axel Koslowski         : Symmetry handling
+   Simone Kossmann        : Meta GGA functionals, TD-DFT gradient, OOMP2, (MP2 Hessian; deprecated post 5.0)
+   Lucas Lang             : DCDCAS
+   Marvin Lechner         : AUTO-CI (C++ implementation), FIC-MRCC
+   Spencer Leger          : CASSCF response
+   Dagmar Lenk            : GEPOL surface, SMD, ORCA-2-JSON
+   Dimitrios Liakos       : Extrapolation schemes; Compound Job, initial MDCI parallelization
+   Dimitrios Manganas     : Further ROCIS development; embedding schemes. LFT, Crystal Embedding
+   Dimitrios Pantazis     : SARC Basis sets
+   Anastasios Papadopoulos: AUTO-CI, single reference methods and gradients
+   Taras Petrenko         : pre 6.0 DFT Hessian and TD-DFT gradient, (ASA, deprecated), ECA, 1-Electron XAS/XES, NRVS
+   Peter Pinski           : DLPNO-MP2, DLPNO-MP2 Gradient
+   Christoph Reimann      : Effective Core Potentials
+   Marius Retegan         : Local ZFS, SOC
+   Christoph Riplinger    : Optimizer, TS searches, QM/MM, DLPNO-CCSD(T), (RO)-DLPNO pert. Triples
+   Michael Roemelt        : Original ROCIS implementation
+   Masaaki Saitow         : Open-shell DLPNO-CCSD energy and density
+   Barbara Sandhoefer     : DKH picture change effects
+   Kantharuban Sivalingam : CASSCF convergence/infrastructure, NEVPT2 and variants, FIC-MRCI
+   Bernardo de Souza      : ESD, SOC TD-DFT
+   Georgi Stoychev        : AutoAux, RI-MP2 NMR, DLPNO-MP2 response, X2C
+   Van Anh Tran           : RI-MP2 g-tensors
+   Willem Van den Heuvel  : Paramagnetic NMR
+   Zikuan Wang            : NOTCH, Electric field optimization 
+   Frank Wennmohs         : Technical directorship and infrastructure
+   Hang Xu                : AUTO-CI-Response properties 
+
+
+ We gratefully acknowledge several colleagues who have allowed us to
+ interface, adapt or use parts of their codes:
+   Stefan Grimme, W. Hujo, H. Kruse, P. Pracht,  : VdW corrections, initial TS optimization,
+                  C. Bannwarth, S. Ehlert,         DFT functionals, gCP, sTDA/sTD-DF
+                  L. Wittmann, M. Mueller
+   Ed Valeev, F. Pavosevic, A. Kumar             : LibInt (2-el integral package), F12 methods
+   Garnet Chan, S. Sharma, J. Yang, R. Olivares  : DMRG
+   Ulf Ekstrom                                   : XCFun DFT Library
+   Mihaly Kallay                                 : mrcc  (arbitrary order and MRCC methods)
+   Frank Weinhold                                : gennbo (NPA and NBO analysis)
+   Simon Mueller                                 : openCOSMO-RS
+   Christopher J. Cramer and Donald G. Truhlar   : smd solvation model
+   Lars Goerigk                                  : TD-DFT with DH, B97 family of functionals
+   V. Asgeirsson, H. Jonsson                     : NEB implementation
+   FAccTs GmbH                                   : IRC, NEB, NEB-TS, DLPNO-Multilevel, CI-OPT
+                                                   MM, QMMM, 2- and 3-layer-ONIOM, Crystal-QMMM,
+                                                   LR-CPCM, SF, NACMEs, symmetry and pop. for TD-DFT,
+                                                   nearIR, NL-DFT gradient (VV10), updates on ESD,
+                                                   ML-optimized integration grids, MBIS, APM,
+                                                   GOAT, DOCKER, SOLVATOR, interface openCOSMO-RS
+   S Lehtola, MJT Oliveira, MAL Marques          : LibXC Library
+   Liviu Ungur et al                             : ANISO software
+
+
+ Your calculation uses the libint2 library for the computation of 2-el integrals
+ For citations please refer to: http://libint.valeyev.net
+
+ Your ORCA version has been built with support for libXC version: 6.2.2
+ For citations please refer to: https://libxc.gitlab.io
+
+ This ORCA versions uses:
+   CBLAS   interface :  Fast vector & matrix operations
+   LAPACKE interface :  Fast linear algebra routines
+   SCALAPACK package :  Parallel linear algebra routines
+   Shared memory     :  Shared parallel matrices
+   BLAS/LAPACK       :  OpenBLAS 0.3.27  USE64BITINT DYNAMIC_ARCH NO_AFFINITY SkylakeX SINGLE_THREADED
+        Core in use  :  SkylakeX
+   Copyright (c) 2011-2014, The OpenBLAS Project
+
+
+Warning: RI is on but no J-basis has been assigned. Assigning Def2/J (nothing to worry about!)
+================================================================================
+
+----- Orbital basis set information -----
+Your calculation utilizes the basis: EPR-III
+   V. Barone, in Recent Advances in Density Functional Methods, Part 1 (ed. D. P. Chong), World Scientific, Singapore, 1995, p. 287.
+   N. Rega, M. Cossi and V. Barone, J. Chem. Phys. 105, 11060 (1996).
+
+----- AuxJ basis set information -----
+Your calculation utilizes the auxiliary basis: def2/J
+   F. Weigend, Phys. Chem. Chem. Phys. 8, 1057 (2006).
+
+================================================================================
+                                        WARNINGS
+                       Please study these warnings very carefully!
+================================================================================
+
+
+================================================================================
+                                       INPUT FILE
+================================================================================
+NAME = NH2_A.inp
+|  1> !UKS B3LYP EPR-III TightSCF
+|  2> 
+|  3> *xyz 0 2
+|  4> N -0.01498947828047 -0.01894387811818 0.00000000000000
+|  5> H  1.03197835263254  0.00908678452370 0.00000000000000
+|  6> H -0.22855980523269  1.00639225931822 0.00000000000000
+|  7> *
+|  8> 
+|  9> %eprnmr
+| 10>     Nuclei = all N { aiso, adip, aorb, fgrad, rho }
+| 11>     Nuclei = all H { aiso, adip, aorb, fgrad, rho }
+| 12> end
+| 13> 
+| 14>                          ****END OF INPUT****
+================================================================================
+
+                       ****************************
+                       * Single Point Calculation *
+                       ****************************
+
+---------------------------------
+CARTESIAN COORDINATES (ANGSTROEM)
+---------------------------------
+  N     -0.014989   -0.018944    0.000000
+  H      1.031978    0.009087    0.000000
+  H     -0.228560    1.006392    0.000000
+
+----------------------------
+CARTESIAN COORDINATES (A.U.)
+----------------------------
+  NO LB      ZA    FRAG     MASS         X           Y           Z
+   0 N     7.0000    0    14.007   -0.028326   -0.035799    0.000000
+   1 H     1.0000    0     1.008    1.950156    0.017172    0.000000
+   2 H     1.0000    0     1.008   -0.431915    1.901806    0.000000
+
+--------------------------------
+INTERNAL COORDINATES (ANGSTROEM)
+--------------------------------
+ N      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.047342998742     0.00000000     0.00000000
+ H      1   2   0     1.047342579717   100.23244931     0.00000000
+
+---------------------------
+INTERNAL COORDINATES (A.U.)
+---------------------------
+ N      0   0   0     0.000000000000     0.00000000     0.00000000
+ H      1   0   0     1.979191435903     0.00000000     0.00000000
+ H      1   2   0     1.979190644059   100.23244931     0.00000000
+
+---------------------
+BASIS SET INFORMATION
+---------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type N   : 12s8p2d1f contracted to 8s5p2d1f pattern {51111111/41111/11/1}
+ Group   2 Type H   : 7s2p contracted to 5s2p pattern {31111/11}
+
+Atom   0N    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+---------------------------------
+AUXILIARY/J BASIS SET INFORMATION
+---------------------------------
+There are 2 groups of distinct atoms
+
+ Group   1 Type N   : 12s5p4d2f1g contracted to 6s4p3d1f1g pattern {711111/2111/211/2/1}
+ Group   2 Type H   : 5s2p1d contracted to 3s1p1d pattern {311/2/1}
+
+Atom   0N    basis set group =>   1
+Atom   1H    basis set group =>   2
+Atom   2H    basis set group =>   2
+------------------------------------------------------------------------------
+                             ORCA STARTUP CALCULATIONS
+                           -- RI-GTO INTEGRALS CHOSEN --
+------------------------------------------------------------------------------
+------------------------------------------------------------------------------
+                   ___                                                        
+                  /   \      - P O W E R E D   B Y -                         
+                 /     \                                                     
+                 |  |  |   _    _      __       _____    __    __             
+                 |  |  |  | |  | |    /  \     |  _  \  |  |  /  |          
+                  \  \/   | |  | |   /    \    | | | |  |  | /  /          
+                 / \  \   | |__| |  /  /\  \   | |_| |  |  |/  /          
+                |  |  |   |  __  | /  /__\  \  |    /   |      \           
+                |  |  |   | |  | | |   __   |  |    \   |  |\   \          
+                \     /   | |  | | |  |  |  |  | |\  \  |  | \   \       
+                 \___/    |_|  |_| |__|  |__|  |_| \__\ |__|  \__/        
+                                                                              
+                      - O R C A' S   B I G   F R I E N D -                    
+                                      &                                       
+                       - I N T E G R A L  F E E D E R -                       
+                                                                              
+ v1 FN, 2020, v2 2021, v3 2022-2024                                           
+------------------------------------------------------------------------------
+
+
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      3
+Number of basis functions                   ...     62
+Number of shells                            ...     30
+Maximum angular momentum                    ...      3
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ (Revised 2003 algorithm where possible)
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+Prescreening option                         ... SCHWARTZ
+   Thresh                                   ... 2.500e-11
+   Tcut                                     ... 2.500e-12
+   Tpresel                                  ... 2.500e-12 
+Coulomb Range Separation                    ... NOT USED
+Exchange Range Separation                   ... NOT USED
+Multipole approximations                    ... NOT USED
+Finite Nucleus Model                        ... NOT USED
+CABS basis                                  ... NOT available
+Auxiliary Coulomb fitting basis             ... AVAILABLE
+   # of basis functions in Aux-J            ...     71
+   # of shells in Aux-J                     ...     25
+   Maximum angular momentum in Aux-J        ...      4
+Auxiliary J/K fitting basis                 ... NOT available
+Auxiliary Correlation fitting basis         ... NOT available
+Auxiliary 'external' fitting basis          ... NOT available
+
+Checking pre-screening integrals            ... done (  0.0 sec) Dimension = 30
+Check shell pair data                       ... done (  0.0 sec)
+Shell pair information
+Shell pair cut-off parameter TPreSel        ...   2.5e-12
+Total number of shell pairs                 ...       465
+Shell pairs after pre-screening             ...       460
+Total number of primitive shell pairs       ...       883
+Primitive shell pairs kept                  ...       822
+          la=0 lb=0:    166 shell pairs
+          la=1 lb=0:    162 shell pairs
+          la=1 lb=1:     45 shell pairs
+          la=2 lb=0:     36 shell pairs
+          la=2 lb=1:     18 shell pairs
+          la=2 lb=2:      3 shell pairs
+          la=3 lb=0:     18 shell pairs
+          la=3 lb=1:      9 shell pairs
+          la=3 lb=2:      2 shell pairs
+          la=3 lb=3:      1 shell pairs
+
+Calculating one electron integrals          ... done (  0.0 sec)
+Calculating RI/J V-Matrix + Cholesky decomp.... done (  0.0 sec)
+Calculating Nuclear repulsion               ... done (  0.0 sec) ENN=      7.402820444422 Eh
+
+Diagonalization of the overlap matrix:
+Smallest eigenvalue                        ... 1.109e-03
+Time for diagonalization                   ...    0.001 sec
+Threshold for overlap eigenvalues          ... 1.000e-07
+Number of eigenvalues below threshold      ... 0
+Time for construction of square roots      ...    0.000 sec
+Total time needed                          ...    0.001 sec
+
+-------------------
+DFT GRID GENERATION
+-------------------
+
+General Integration Accuracy     IntAcc      ... 4.388
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 4 (Lebedev-302)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... off
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...    13554
+Total number of batches                      ...      213
+Average number of points per batch           ...       63
+Average number of grid points per atom       ...     4518
+
+--------------------
+COSX GRID GENERATION
+--------------------
+
+GRIDX 1
+-------
+General Integration Accuracy     IntAcc      ... 3.816
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 1 (Lebedev-50)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...     1698
+Total number of batches                      ...       15
+Average number of points per batch           ...      113
+Average number of grid points per atom       ...      566
+UseSFitting                                  ... on
+
+GRIDX 2
+-------
+General Integration Accuracy     IntAcc      ... 4.020
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 2 (Lebedev-110)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...     4155
+Total number of batches                      ...       34
+Average number of points per batch           ...      122
+Average number of grid points per atom       ...     1385
+UseSFitting                                  ... on
+
+GRIDX 3
+-------
+General Integration Accuracy     IntAcc      ... 4.338
+Radial Grid Type                 RadialGrid  ... OptM3 with GC (2021)
+Angular Grid (max. ang.)         AngularGrid ... 3 (Lebedev-194)
+Angular grid pruning method      GridPruning ... 4 (adaptive)
+Weight generation scheme         WeightScheme... mBecke (2022)
+Basis function cutoff            BFCut       ... 1.0000e-11
+Integration weight cutoff        WCut        ... 1.0000e-14
+Partially contracted basis set               ... on
+Rotationally invariant grid construction     ... off
+Angular grids for H and He will be reduced by one unit
+Diffuse basis detected: some atoms will have their outermost
+                        angular grid increased by 1.
+
+Total number of grid points                  ...     9558
+Total number of batches                      ...       77
+Average number of points per batch           ...      124
+Average number of grid points per atom       ...     3186
+UseSFitting                                  ... on
+Initializing property integral containers    ... done (  0.0 sec)
+
+SHARK setup successfully completed in   0.2 seconds
+
+Maximum memory used throughout the entire STARTUP-calculation: 12.9 MB
+-------------------------------------------------------------------------------
+                                 ORCA GUESS
+                   Start orbitals & Density for SCF / CASSCF
+-------------------------------------------------------------------------------
+
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Density Functional     Method          .... DFT(GTOs)
+ Exchange Functional    Exchange        .... B88
+   X-Alpha parameter    XAlpha          ....  0.666667
+   Becke's b parameter  XBeta           ....  0.004200
+ Correlation Functional Correlation     .... LYP
+ LDA part of GGA corr.  LDAOpt          .... VWN-5
+ Gradients option       PostSCFGGA      .... off
+ Hybrid DFT is turned on
+   Fraction HF Exchange ScalHFX         ....  0.200000
+   Scaling of DF-GGA-X  ScalDFX         ....  0.720000
+   Scaling of DF-GGA-C  ScalDFC         ....  0.810000
+   Scaling of DF-LDA-C  ScalLDAC        ....  1.000000
+   Perturbative correction              ....  0.000000
+   NL short-range parameter             ....  4.800000
+ RI-approximation to the Coulomb term is turned on
+   Number of AuxJ basis functions       .... 71
+   RIJ-COSX (HFX calculated with COS-X)).... on
+
+
+General Settings:
+ Integral files         IntName         .... NH2_A
+ Hartree-Fock type      HFTyp           .... UHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    2
+ Number of Electrons    NEL             ....    9
+ Basis Dimension        Dim             ....   62
+ Nuclear Repulsion      ENuc            ....      7.4028204444 Eh
+
+Convergence Acceleration:
+ AO-DIIS                CNVDIIS         .... on
+   Start iteration      DIISMaxIt       ....    12
+   Startup error        DIISStart       ....  0.200000
+   # of expansion vecs  DIISMaxEq       ....     5
+   Bias factor          DIISBfac        ....   1.050
+   Max. coefficient     DIISMaxC        ....  10.000
+ MO-DIIS                CNVKDIIS        .... off
+ Trust-Rad. Augm. Hess. CNVTRAH         .... auto
+   Auto Start mean grad. ratio tolernc. ....  1.125000
+   Auto Start start iteration           ....    50
+   Auto Start num. interpolation iter.  ....    10
+   Max. Number of Micro iterations      ....    24
+   Max. Number of Macro iterations      .... Maxiter - #DIIS iter
+   Number of Davidson start vectors     ....     2
+   Converg. threshold    (grad. norm)   ....   1.000e-05
+   Grad. Scal. Fac. for Micro threshold ....   0.100
+   Minimum threshold for Micro iter.    ....   1.000e-02
+   NR start threshold (gradient norm)   ....   1.000e-04
+   Initial trust radius                 ....   0.400
+   Minimum AH scaling param. (alpha)    ....   1.000
+   Maximum AH scaling param. (alpha)    .... 1000.000
+   Quad. conv. algorithm                .... NR
+   White noise on init. David. guess    .... on
+   Maximum white noise                  ....   0.010
+   Pseudo random numbers                .... off
+   Inactive MOs                         .... canonical
+   Orbital update algorithm             .... Taylor
+   Preconditioner                       .... Diag
+   Full preconditioner red. dimension   ....   250
+ SOSCF                  CNVSOSCF        .... on
+   Start iteration      SOSCFMaxIt      ....   150
+   Startup grad/error   SOSCFStart      ....  0.003300
+   Hessian update       SOSCFHessUp     .... L-BFGS
+ Level Shifting         CNVShift        .... on
+   Level shift para.    LevelShift      ....    0.2500
+   Turn off err/grad.   ShiftErr        ....    0.0010
+ Zerner damping         CNVZerner       .... off
+ Static damping         CNVDamp         .... on
+   Fraction old density DampFac         ....    0.7000
+   Max. Damping (<1)    DampMax         ....    0.9800
+   Min. Damping (>=0)   DampMin         ....    0.0000
+   Turn off err/grad.   DampErr         ....    0.1000
+
+SCF Procedure:
+ Maximum # iterations   MaxIter         ....   125
+ SCF integral mode      SCFMode         .... Direct
+   Integral package                     .... SHARK and LIBINT hybrid scheme
+ Reset frequency        DirectResetFreq ....    20
+ Integral Threshold     Thresh          ....  2.500e-11 Eh
+ Primitive CutOff       TCut            ....  2.500e-12 Eh
+
+Convergence Tolerance:
+ Convergence Check Mode ConvCheckMode   .... Total+1el-Energy
+ Convergence forced     ConvForced      .... 0
+ Energy Change          TolE            ....  1.000e-08 Eh
+ 1-El. energy change                    ....  1.000e-05 Eh
+ Orbital Gradient       TolG            ....  1.000e-05
+ Orbital Rotation angle TolX            ....  1.000e-05
+ DIIS Error             TolErr          ....  5.000e-07
+
+------------------------------
+INITIAL GUESS: MODEL POTENTIAL
+------------------------------
+Loading Hartree-Fock densities                     ... done
+Calculating cut-offs                               ... done
+Initializing the effective Hamiltonian             ... done
+Setting up the integral package (SHARK)            ... done
+Starting the Coulomb interaction                   ... done (   0.0 sec)
+Making the grid                                    ... done (   0.0 sec)
+Mapping shells                                     ... done
+Starting the XC term evaluation                    ... done (   0.0 sec)
+  promolecular density results
+     # of electrons  =      8.998973510
+     EX              =     -7.083808356
+     EC              =     -0.281349252
+     EX+EC           =     -7.365157608
+Transforming the Hamiltonian                       ... done (   0.0 sec)
+Diagonalizing the Hamiltonian                      ... done (   0.0 sec)
+Back transforming the eigenvectors                 ... done (   0.0 sec)
+Now organizing SCF variables                       ... done
+                      ------------------
+                      INITIAL GUESS DONE (   0.0 sec)
+                      ------------------
+             **** ENERGY FILE WAS UPDATED (NH2_A.en.tmp) ****
+Finished Guess after   0.1 sec
+Maximum memory used throughout the entire GUESS-calculation: 7.4 MB
+
+-------------------------------------------------------------------------------------------
+                                      ORCA LEAN-SCF
+                              memory conserving SCF solver
+-------------------------------------------------------------------------------------------
+
+----------------------------------------D-I-I-S--------------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     DIISErr   Damp  Time(sec)
+-------------------------------------------------------------------------------------------
+               ***  Starting incremental Fock matrix formation  ***
+    1    -55.8306134814637147     0.00e+00  1.14e-03  1.94e-02  1.05e-01  0.700   0.2
+    2    -55.8519035707120963    -2.13e-02  8.30e-04  1.37e-02  4.92e-02  0.700   0.1
+                               ***Turning on AO-DIIS***
+    3    -55.8598647707343048    -7.96e-03  3.12e-04  3.88e-03  2.26e-02  0.700   0.1
+    4    -55.8645858446838446    -4.72e-03  4.76e-04  5.23e-03  1.62e-02  0.000   0.1
+    5    -55.8753814914793878    -1.08e-02  1.09e-04  1.48e-03  3.70e-03  0.000   0.1
+                              *** Initializing SOSCF ***
+---------------------------------------S-O-S-C-F--------------------------------------
+Iteration    Energy (Eh)           Delta-E    RMSDP     MaxDP     MaxGrad    Time(sec)
+--------------------------------------------------------------------------------------
+    6    -55.8754353060874820    -5.38e-05  4.30e-05  5.23e-04  1.11e-03     0.1
+               *** Restarting incremental Fock matrix formation ***
+    7    -55.8754279310780717     7.38e-06  2.84e-05  4.56e-04  4.80e-04     0.2
+    8    -55.8754296434532307    -1.71e-06  1.34e-05  2.40e-04  1.83e-04     0.2
+    9    -55.8754297943814464    -1.51e-07  4.62e-06  8.22e-05  1.21e-04     0.2
+   10    -55.8754299035444930    -1.09e-07  1.68e-06  2.67e-05  3.28e-05     0.1
+   11    -55.8754299098447902    -6.30e-09  2.76e-07  5.11e-06  4.86e-06     0.1
+                 **** Energy Check signals convergence ****
+
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+               *****************************************************
+
+Recomputing exchange energy using gridx3       ... done (    0.204 sec)
+Old exchange energy                            :     -1.449678376 Eh
+New exchange energy                            :     -1.449681112 Eh
+Exchange energy change after final integration :     -0.000002736 Eh
+Total energy after final integration           :    -55.875432646 Eh
+             **** ENERGY FILE WAS UPDATED (NH2_A.en.tmp) ****
+
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :        -55.87543264586789 Eh           -1520.44782 eV
+
+Components:
+Nuclear Repulsion  :          7.40282044442168 Eh             201.44099 eV
+Electronic Energy  :        -63.27825035426647 Eh           -1721.88873 eV
+One Electron Energy:        -89.93660142759657 Eh           -2447.29934 eV
+Two Electron Energy:         26.65835107333010 Eh             725.41061 eV
+
+Virial components:
+Potential Energy   :       -111.47764320594391 Eh           -3033.46089 eV
+Kinetic Energy     :         55.60221056007602 Eh            1513.01307 eV
+Virial Ratio       :          2.00491387092419
+
+DFT components:
+N(Alpha)           :        5.000000247236 electrons
+N(Beta)            :        4.000000668376 electrons
+N(Total)           :        9.000000915612 electrons
+E(X)               :       -5.762537535111 Eh       
+E(C)               :       -0.332198073466 Eh       
+E(XC)              :       -6.094735608578 Eh       
+
+---------------
+SCF CONVERGENCE
+---------------
+
+  Last Energy change         ...    6.3003e-09  Tolerance :   1.0000e-08
+  Last MAX-Density change    ...    5.1084e-06  Tolerance :   1.0000e-07
+  Last RMS-Density change    ...    2.7642e-07  Tolerance :   5.0000e-09
+  Last DIIS Error            ...    1.1140e-03  Tolerance :   5.0000e-07
+  Last Orbital Gradient      ...    4.8572e-06  Tolerance :   1.0000e-05
+  Last Orbital Rotation      ...    8.2122e-06  Tolerance :   1.0000e-05
+
+
+----------------------
+UHF SPIN CONTAMINATION
+----------------------
+
+Warning: in a DFT calculation there is little theoretical justification to 
+         calculate <S**2> as in Hartree-Fock theory. We will do it anyways
+         but you should keep in mind that the values have only limited relevance
+
+Expectation value of <S**2>     :     0.753368
+Ideal value S*(S+1) for S=0.5   :     0.750000
+Deviation                       :     0.003368
+
+----------------
+ORBITAL ENERGIES
+----------------
+                 SPIN UP ORBITALS
+  NO   OCC          E(Eh)            E(eV) 
+   0   1.0000     -14.355657      -390.6373 
+   1   1.0000      -0.854140       -23.2423 
+   2   1.0000      -0.466599       -12.6968 
+   3   1.0000      -0.339053        -9.2261 
+   4   1.0000      -0.322366        -8.7720 
+   5   0.0000      -0.008161        -0.2221 
+   6   0.0000       0.045557         1.2397 
+   7   0.0000       0.066766         1.8168 
+   8   0.0000       0.070607         1.9213 
+   9   0.0000       0.097327         2.6484 
+  10   0.0000       0.115836         3.1521 
+  11   0.0000       0.229924         6.2565 
+  12   0.0000       0.241425         6.5695 
+  13   0.0000       0.383415        10.4333 
+  14   0.0000       0.385774        10.4974 
+  15   0.0000       0.390459        10.6249 
+
+                 SPIN DOWN ORBITALS
+  NO   OCC          E(Eh)            E(eV) 
+   0   1.0000     -14.335736      -390.0952 
+   1   1.0000      -0.800684       -21.7877 
+   2   1.0000      -0.452695       -12.3184 
+   3   1.0000      -0.314949        -8.5702 
+   4   0.0000      -0.122316        -3.3284 
+   5   0.0000      -0.004342        -0.1181 
+   6   0.0000       0.047096         1.2816 
+   7   0.0000       0.071566         1.9474 
+   8   0.0000       0.081060         2.2058 
+   9   0.0000       0.096831         2.6349 
+  10   0.0000       0.119656         3.2560 
+  11   0.0000       0.241441         6.5699 
+  12   0.0000       0.245778         6.6880 
+  13   0.0000       0.386595        10.5198 
+  14   0.0000       0.396626        10.7927 
+*Only the first 10 virtual orbitals were printed.
+
+                    ********************************
+                    * MULLIKEN POPULATION ANALYSIS *
+                    ********************************
+
+--------------------------------------------
+MULLIKEN ATOMIC CHARGES AND SPIN POPULATIONS
+--------------------------------------------
+   0 N :   -0.446464    1.051333
+   1 H :    0.223206   -0.025669
+   2 H :    0.223259   -0.025664
+Sum of atomic charges         :   -0.0000000
+Sum of atomic spin populations:    1.0000000
+
+-----------------------------------------------------
+MULLIKEN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS
+-----------------------------------------------------
+CHARGE
+  0 N s       :     3.820037  s :     3.820037
+      pz      :     0.974256  p :     3.594933
+      px      :     1.277804
+      py      :     1.342873
+      dz2     :     0.006520  d :     0.030376
+      dxz     :     0.000673
+      dyz     :     0.001075
+      dx2y2   :     0.020024
+      dxy     :     0.002083
+      f0      :    -0.000014  f :     0.001118
+      f+1     :     0.000349
+      f-1     :     0.000324
+      f+2     :     0.000000
+      f-2     :     0.000005
+      f+3     :     0.000360
+      f-3     :     0.000094
+
+  1 H s       :     0.731742  s :     0.731742
+      pz      :     0.012001  p :     0.045053
+      px      :     0.012690
+      py      :     0.020362
+
+  2 H s       :     0.731691  s :     0.731691
+      pz      :     0.012003  p :     0.045050
+      px      :     0.019308
+      py      :     0.013739
+
+
+SPIN
+  0 N s       :     0.035237  s :     0.035237
+      pz      :     0.974256  p :     1.014601
+      px      :     0.023032
+      py      :     0.017314
+      dz2     :    -0.000598  d :     0.002255
+      dxz     :     0.000673
+      dyz     :     0.001075
+      dx2y2   :     0.001007
+      dxy     :     0.000096
+      f0      :    -0.000014  f :    -0.000760
+      f+1     :    -0.000395
+      f-1     :    -0.000374
+      f+2     :     0.000000
+      f-2     :     0.000005
+      f+3     :     0.000004
+      f-3     :     0.000014
+
+  1 H s       :    -0.035815  s :    -0.035815
+      pz      :     0.012001  p :     0.010145
+      px      :    -0.000669
+      py      :    -0.001186
+
+  2 H s       :    -0.035810  s :    -0.035810
+      pz      :     0.012003  p :     0.010146
+      px      :    -0.001053
+      py      :    -0.000805
+
+
+
+                     *******************************
+                     * LOEWDIN POPULATION ANALYSIS *
+                     *******************************
+
+-------------------------------------------
+LOEWDIN ATOMIC CHARGES AND SPIN POPULATIONS
+-------------------------------------------
+   0 N :   -0.098679    0.946114
+   1 H :    0.049338    0.026941
+   2 H :    0.049341    0.026945
+
+----------------------------------------------------
+LOEWDIN REDUCED ORBITAL CHARGES AND SPIN POPULATIONS
+----------------------------------------------------
+CHARGE
+  0 N s       :     3.313951  s :     3.313951
+      pz      :     0.916580  p :     3.729678
+      px      :     1.372451
+      py      :     1.440648
+      dz2     :     0.011097  d :     0.051078
+      dxz     :     0.000137
+      dyz     :     0.000220
+      dx2y2   :     0.037239
+      dxy     :     0.002385
+      f0      :     0.000084  f :     0.003971
+      f+1     :     0.000767
+      f-1     :     0.000672
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :     0.001500
+      f-3     :     0.000947
+
+  1 H s       :     0.725907  s :     0.725907
+      pz      :     0.041489  p :     0.224755
+      px      :     0.123793
+      py      :     0.059473
+
+  2 H s       :     0.725899  s :     0.725899
+      pz      :     0.041490  p :     0.224760
+      px      :     0.054529
+      py      :     0.128742
+
+
+SPIN
+  0 N s       :     0.013183  s :     0.013183
+      pz      :     0.916580  p :     0.934672
+      px      :     0.010670
+      py      :     0.007423
+      dz2     :     0.000127  d :    -0.001078
+      dxz     :     0.000137
+      dyz     :     0.000220
+      dx2y2   :    -0.001460
+      dxy     :    -0.000103
+      f0      :     0.000084  f :    -0.000663
+      f+1     :    -0.000325
+      f-1     :    -0.000297
+      f+2     :     0.000000
+      f-2     :     0.000000
+      f+3     :    -0.000074
+      f-3     :    -0.000051
+
+  1 H s       :    -0.017716  s :    -0.017716
+      pz      :     0.041489  p :     0.044657
+      px      :     0.003862
+      py      :    -0.000694
+
+  2 H s       :    -0.017712  s :    -0.017712
+      pz      :     0.041490  p :     0.044657
+      px      :    -0.000386
+      py      :     0.003553
+
+
+
+                      *****************************
+                      * MAYER POPULATION ANALYSIS *
+                      *****************************
+
+  NA   - Mulliken gross atomic population
+  ZA   - Total nuclear charge
+  QA   - Mulliken gross atomic charge
+  VA   - Mayer's total valence
+  BVA  - Mayer's bonded valence
+  FA   - Mayer's free valence
+
+  ATOM       NA         ZA         QA         VA         BVA        FA
+  0 N      7.4465     7.0000    -0.4465     2.8437     1.8851     0.9586
+  1 H      0.7768     1.0000     0.2232     0.9561     0.9547     0.0014
+  2 H      0.7767     1.0000     0.2233     0.9561     0.9547     0.0014
+
+  Mayer bond orders larger than 0.100000
+B(  0-N ,  1-H ) :   0.9425 B(  0-N ,  2-H ) :   0.9425 
+
+-------
+TIMINGS
+-------
+
+Total SCF time: 0 days 0 hours 0 min 1 sec 
+
+Total time                  ....       1.823 sec
+Sum of individual times     ....       1.815 sec  ( 99.6%)
+
+SCF preparation             ....       0.055 sec  (  3.0%)
+Fock matrix formation       ....       1.736 sec  ( 95.2%)
+  Startup                   ....       0.001 sec  (  0.1% of F)
+  Split-RI-J                ....       0.098 sec  (  5.6% of F)
+  Chain of spheres X        ....       1.058 sec  ( 60.9% of F)
+  XC integration            ....       0.572 sec  ( 33.0% of F)
+    XC Preparation          ....       0.000 sec  (  0.0% of XC)
+    Basis function eval.    ....       0.159 sec  ( 27.8% of XC)
+    Density eval.           ....       0.092 sec  ( 16.2% of XC)
+    XC-Functional eval.     ....       0.066 sec  ( 11.5% of XC)
+    XC-Potential eval.      ....       0.229 sec  ( 40.0% of XC)
+Diagonalization             ....       0.000 sec  (  0.0%)
+Density matrix formation    ....       0.008 sec  (  0.4%)
+Total Energy calculation    ....       0.001 sec  (  0.0%)
+Population analysis         ....       0.001 sec  (  0.1%)
+Orbital Transformation      ....       0.003 sec  (  0.1%)
+Orbital Orthonormalization  ....       0.000 sec  (  0.0%)
+DIIS solution               ....       0.008 sec  (  0.4%)
+SOSCF solution              ....       0.004 sec  (  0.2%)
+Finished LeanSCF after   1.8 sec
+
+Maximum memory used throughout the entire LEANSCF-calculation: 7.0 MB
+
+------------------------------------------------------------------------------
+                         ORCA PROPERTY INTEGRAL CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                   ... NH2_A.gbw
+Number of atoms                           ...      3
+Number of basis functions                 ...     62
+Max core memory                           ...   1024 MB
+
+Dipole integrals                          ... YES
+Quadrupole integrals                      ...  NO
+Linear momentum integrals                 ...  NO
+Angular momentum integrals                ...  NO
+Higher moments length integrals           ...  NO
+Higher moments velocity integrals         ...  NO
+Kinetic energy integrals                  ...  NO
+GIAO right hand sides                     ...  NO
+GIAO dipole derivative integrals          ...  NO
+SOC integrals                             ... YES
+EPR diamagnetic integrals (GIAO)          ...  NO
+EPR gauge integrals                       ...  NO
+Field gradient integrals                  ... YES (   3 nuclei)
+Spin-dipole/Fermi contact integrals       ... YES (   3 nuclei)
+Contact density integrals                 ... YES (   3 nuclei)
+Nucleus-orbit integrals                   ... YES (   3 nuclei)
+Geometric perturbations                   ...  NO (   3 nuclei)
+
+Choice of electric origin   ... Center of mass
+Position of electric origin ... (  0.0707,  0.0894,  0.0000) 
+Choice of magnetic origin   ... GIAO
+Position of magnetic origin ... (  0.0000,  0.0000,  0.0000) 
+
+Calculating integrals                     ... Electric Dipole (Length)     done (  0.0 sec)
+Calculating integrals                     ... Nucleus-Orbit integrals      done (  0.0 sec)
+Calculating integrals                     ... Contact density integrals    done (  0.0 sec)
+Calculating integrals                     ... SD/FC/EFG integrals          done (  0.0 sec)
+Calculating integrals                     ... Spin-Orbit Coupling
+  Spin-orbit operator                     ... Spin-Orbit Mean-Field (SOMF)
+      1-El-Flag                           ...  1 ON
+      Coulomb-Flag                        ...  3 ON (Via RI)
+      Exchange-Flag                       ...  3 ON (AMFI type)
+      DFT-Correlation Flag                ...  0 OFF
+      Max-Center                          ...  4   
+      Relativistic Picture Change         ... OFF     
+  RI-J SOMF                               ... done (  0.0 sec)
+  One-electron part                       ... done (  0.0 sec)
+  Two-electron DoJ,X=0,1 MaxCenter=1      ... done (  0.2 sec)
+  SOC integrals done (  0.2 sec)
+
+Property integrals calculated in   0.2 sec
+
+Maximum memory used throughout the entire PROPINT-calculation: 7.6 MB
+
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -55.875432645868
+-------------------------   --------------------
+
+------------------------------------------------------------------------------
+                            ORCA SCF RESPONSE CALCULATION
+------------------------------------------------------------------------------
+
+GBWName                                 ... NH2_A.gbw
+Number of atoms                         ...      3
+Number of basis functions               ...     62
+Max core memory                         ...   1024 MB
+
+Electric field perturbation             ...  NO
+Quadrupolar field perturbation          ...  NO
+Magnetic field perturbation (no GIAO)   ...  NO
+Magnetic field perturbation (with GIAO) ...  NO
+Linear momentum (velocity) perturbation ...  NO
+Spin-orbit coupling perturbation        ...  NO
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.070750     0.089427     0.000000
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+Nuclear geometric perturbations         ...  NO (   9 perturbations)
+Nucleus-orbit perturbations             ... YES (   9 perturbations)
+Spin-dipole/Fermi contact perturbations ...  NO (   0 perturbations)
+
+Total number of real perturbations      ...      0
+Total number of imaginary perturbations ...      9
+Total number of triplet perturbations   ...      0
+Total number of SOC perturbations       ...      0
+
+
+                              ***************************
+                              * IMAGINARY PERTURBATIONS *
+                              ***************************
+
+
+
+-------------------
+SHARK CP-SCF DRIVER
+-------------------
+
+Dimension of the orbital basis          ...     62
+Dimension of the CPSCF-problem          ...    517
+Number of operators                     ...      2
+Max. number of iterations               ...    128
+Convergence Tolerance                   ... 1.0e-04
+Number of perturbations                 ...      9
+Perturbation type                       ... IMAGINARY
+
+----------------------------
+POPLE LINEAR EQUATION SOLVER
+----------------------------
+
+  ITERATION   0:   ||err||_max =   4.8775e+00 (   0.1 sec   0/  9 done)
+  ITERATION   1:   ||err||_max =   5.1867e-01 (   0.1 sec   0/  9 done)
+  ITERATION   2:   ||err||_max =   6.4201e-02 (   0.1 sec   2/  9 done)
+  ITERATION   3:   ||err||_max =   5.3481e-03 (   0.1 sec   3/  9 done)
+  ITERATION   4:   ||err||_max =   3.2180e-04 (   0.1 sec   7/  9 done)
+  ITERATION   5:   ||err||_max =   1.4423e-05 (   0.1 sec   9/  9 done)
+
+CP-SCF equations solved in   0.4 sec
+Response densities calculated in   0.0 sec
+
+Maximum memory used throughout the entire SCFRESP-calculation: 11.5 MB
+
+------------------------------------------------------------------------------
+                              ORCA PROPERTY CALCULATIONS
+------------------------------------------------------------------------------
+
+GBWName                                 ... NH2_A.gbw
+Number of atoms                         ...      3
+Number of basis functions               ...     62
+Max core memory                         ...   1024 MB
+
+Electric properties:
+Dipole moment                           ... YES
+Quadrupole moment                       ...  NO
+Static polarizability (Dipole/Dipole)   ...  NO
+Static polarizability (Dipole/Quad.)    ...  NO
+Static polarizability (Quad./Quad.)     ...  NO
+Static polarizability (Velocity)        ...  NO
+
+Atomic electric properties:
+Dipole moment                           ...  NO
+Quadrupole moment                       ...  NO
+Static polarizability                   ...  NO
+
+Choice of electric origin               ... Center of mass
+Position of electric origin             ...     0.070750     0.089427     0.000000
+
+General magnetic properties:
+Magnetizability                         ...  NO
+
+EPR properties:
+g-Tensor (aka g-matrix)                 ...  NO
+Zero-Field splitting spin-orbit         ...  NO
+Zero-field splitting spin-spin          ...  NO
+Hyperfine couplings                     ... YES (   3 nuclei)
+Quadrupole couplings                    ... YES (   3 nuclei)
+Contact density                         ... YES (   3 nuclei)
+
+NMR properties:
+Chemical shifts                         ...  NO (   0 nuclei)
+Spin-rotation constants                 ...  NO (   0 nuclei)
+Spin-spin couplings                     ...  NO (   0 nuclei,    0 pairs)
+
+Choice of magnetic origin               ... GIAO
+Position of magnetic origin             ...     0.000000     0.000000     0.000000
+
+Properties with geometric perturbations:
+SCF Hessian                             ...  NO
+IR spectrum                             ...  NO
+VCD spectrum                            ...  NO
+X-ray spectroscopy properties:
+SCF XES/XAS/RIXS spectra                ...  NO
+
+
+-------------
+DIPOLE MOMENT
+-------------
+
+Method             : SCF
+Type of density    : Electron Density
+Multiplicity       :   2
+Irrep              :   0
+Energy             :   -55.8754326458678889 Eh
+Relativity type    : 
+Basis              : AO
+                                X                 Y                 Z
+Electronic contribution:     -0.217634653      -0.275039975      -0.000000007
+Nuclear contribution   :      0.683210481       0.863538990       0.000000000
+                        -----------------------------------------
+Total Dipole Moment    :      0.465575828       0.588499015      -0.000000007
+                        -----------------------------------------
+Magnitude (a.u.)       :      0.750394524
+Magnitude (Debye)      :      1.907351300
+
+
+
+--------------------
+Rotational spectrum 
+--------------------
+ 
+Rotational constants in cm-1:            21.207844            12.946291             8.038936 
+Rotational constants in MHz :        635795.159963        388120.025859        241001.244383 
+
+Dipole components along the rotational axes: 
+x,y,z [a.u.] :     0.000023     0.750395    -0.000000 
+x,y,z [Debye]:     0.000058     1.907351    -0.000000 
+
+ 
+
+Dipole moment calculation done in   0.0 sec 
+
+-----------------------------------------
+ELECTRIC AND MAGNETIC HYPERFINE STRUCTURE (3 nuclei)
+-----------------------------------------
+
+Number of nuclei to compute A(iso)       :     3
+Number of nuclei to compute A(dip)       :     3
+Number of nuclei to compute A(orb)       :     3
+Number of nuclei to compute A(dia)       :     3
+Number of nuclei to compute EFG          :     3
+Number of nuclei to compute Rho(0)       :     3
+Relativistic treatment                   :  Off
+
+Method             : SCF
+Type of density    : Electron Density
+Multiplicity       :   2
+Irrep              :   0
+Energy             :   -55.8754326458678889 Eh
+Relativity type    : 
+Basis              : AO
+ -----------------------------------------------------------
+ Nucleus   0N : A  : Isotope=   14 I=  1.0 P= 38.5677 MHz/au**3 
+                Q  : Isotope=   14 I=  1.0 Q=  0.0204 barn      
+                HFC: iso  =YES dip=YES orb=YES gauge=YES    
+                EFG: fgrad=YES rho=YES                      
+ -----------------------------------------------------------
+
+ Total HFC matrix (all values in MHz): 
+ ----------------------------------------------------------------
+               -15.7051              -0.6720              -0.0000
+                -0.6720             -16.0228              -0.0000
+                -0.0000              -0.0000             117.2206
+
+ A(FC)          28.4749              28.4749              28.4749
+ A(SD)         -43.8380             -44.9167              88.7547
+ A(ORB+DIA)      0.1898              -0.1127              -0.0089    A(PC) =    0.0227
+ A(ORB)          0.1896              -0.1128              -0.0089    A(PC) =    0.0227
+ A(DIA)          0.0001               0.0001              -0.0000    A(PC) =    0.0001
+             ----------           ----------           ----------
+ A(Tot)        -15.1734             -16.5545             117.2206    A(iso)=   28.4976
+ Orientation: 
+  X           0.7842430            0.6204538           -0.0000000
+  Y          -0.6204538            0.7842430           -0.0000000
+  Z           0.0000000            0.0000000            1.0000000
+
+Notes:  (1) The A matrix conforms to the "SAI" spin Hamiltonian convention.
+        (2) Tensor is right-handed.
+
+ Raw EFG matrix (all values in a.u.**-3):
+ ------------------------------------------------------
+             -0.2512513      -0.4164869       0.0000000
+             -0.4164869      -0.4482350       0.0000000
+              0.0000000       0.0000000       0.6994863
+
+ V(Tot)       0.0782312       0.6994863      -0.7777174
+ Orientation: 
+     X       -0.7842624       0.0000000       0.6204293
+     Y        0.6204293       0.0000000       0.7842624
+     Z        0.0000000       1.0000000      -0.0000000
+
+ Note: Tensor is right-handed
+
+ Contributions:
+ V(El )      -0.1194923       0.9574549  -0.8379626
+ V(Nuc)       0.1977234      -0.2579686   0.0602452
+
+ Quadrupole tensor eigenvalues (in MHz;Q= 0.0204 I=  1.0)
+  e**2qQ            =    -3.735132 MHz 
+  e**2qQ/(4I*(2I-1))=    -0.933783 MHz 
+  eta               =     0.798819
+  NOTE: the diagonal representation of the SH term I*Q*I = e**2qQ/(4I(2I-1))*[-(1-eta),-(1+eta),2]
+
+ RHO(0)=    200.881032038 a.u.**-3
+
+ -----------------------------------------------------------
+ Nucleus   1H : A  : Isotope=    1 I=  0.5 P=533.5514 MHz/au**3 
+                Q  : Isotope=    2 I=  1.0 Q=  0.0029 barn      
+                HFC: iso  =YES dip=YES orb=YES gauge=YES    
+                EFG: fgrad=YES rho=YES                      
+ -----------------------------------------------------------
+
+ Total HFC matrix (all values in MHz): 
+ ----------------------------------------------------------------
+                -0.8895               0.1728               0.0000
+                 0.0850            -114.3385              -0.0000
+                 0.0000              -0.0000             -69.6123
+
+ A(FC)         -61.7044             -61.7044             -61.7044
+ A(SD)          60.6160              -7.9048             -52.7112
+ A(ORB+DIA)      0.1990              -0.0032               0.0770    A(PC) =    0.0909
+ A(ORB)          0.1904              -0.0010               0.0748    A(PC) =    0.0881
+ A(DIA)          0.0085              -0.0022               0.0022    A(PC) =    0.0028
+             ----------           ----------           ----------
+ A(Tot)         -0.8894             -69.6123            -114.3386    A(iso)=  -61.6134
+ Orientation: 
+  X          -0.9999988           -0.0000000           -0.0015233
+  Y          -0.0015233           -0.0000000            0.9999988
+  Z          -0.0000000            1.0000000            0.0000000
+
+Notes:  (1) The A matrix conforms to the "SAI" spin Hamiltonian convention.
+        (2) Tensor is right-handed.
+
+ Raw EFG matrix (all values in a.u.**-3):
+ ------------------------------------------------------
+              0.3279829      -0.0028434       0.0000000
+             -0.0028434      -0.1748479      -0.0000000
+              0.0000000      -0.0000000      -0.1531350
+
+ V(Tot)      -0.1531350      -0.1748640       0.3279990
+ Orientation: 
+     X       -0.0000000       0.0056544      -0.9999840
+     Y       -0.0000000       0.9999840       0.0056544
+     Z        1.0000000       0.0000000      -0.0000000
+
+ Note: Tensor is right-handed
+
+ Contributions:
+ V(El )       0.7854384       0.7202391  -1.5056775
+ V(Nuc)      -0.9385734      -0.8951031   1.8336765
+
+ Quadrupole tensor eigenvalues (in MHz;Q= 0.0029 I=  1.0)
+  e**2qQ            =     0.220248 MHz 
+  e**2qQ/(4I*(2I-1))=     0.055062 MHz 
+  eta               =     0.066247
+  NOTE: the diagonal representation of the SH term I*Q*I = e**2qQ/(4I(2I-1))*[-(1-eta),-(1+eta),2]
+
+ RHO(0)=      0.464440449 a.u.**-3
+
+ -----------------------------------------------------------
+ Nucleus   2H : A  : Isotope=    1 I=  0.5 P=533.5514 MHz/au**3 
+                Q  : Isotope=    2 I=  1.0 Q=  0.0029 barn      
+                HFC: iso  =YES dip=YES orb=YES gauge=YES    
+                EFG: fgrad=YES rho=YES                      
+ -----------------------------------------------------------
+
+ Total HFC matrix (all values in MHz): 
+ ----------------------------------------------------------------
+              -108.3745             -25.3260               0.0000
+               -25.2381              -6.8188               0.0000
+                 0.0000               0.0000             -69.5960
+
+ A(FC)         -61.6873             -61.6873             -61.6873
+ A(SD)          60.6153              -7.9054             -52.7098
+ A(ORB+DIA)      0.1991              -0.0032               0.0769    A(PC) =    0.0909
+ A(ORB)          0.1905              -0.0010               0.0747    A(PC) =    0.0881
+ A(DIA)          0.0085              -0.0022               0.0022    A(PC) =    0.0028
+             ----------           ----------           ----------
+ A(Tot)         -0.8730             -69.5960            -114.3203    A(iso)=  -61.5964
+ Orientation: 
+  X           0.2292697           -0.0000000            0.9733629
+  Y          -0.9733629            0.0000000            0.2292697
+  Z          -0.0000000           -1.0000000           -0.0000000
+
+Notes:  (1) The A matrix conforms to the "SAI" spin Hamiltonian convention.
+        (2) Tensor is right-handed.
+
+ Raw EFG matrix (all values in a.u.**-3):
+ ------------------------------------------------------
+             -0.1469618      -0.1151086      -0.0000000
+             -0.1151086       0.3000908       0.0000000
+             -0.0000000       0.0000000      -0.1531290
+
+ V(Tot)      -0.1531290      -0.1748595       0.3279884
+ Orientation: 
+     X       -0.0000000       0.9718646      -0.2355403
+     Y       -0.0000000       0.2355403       0.9718646
+     Z        1.0000000       0.0000000       0.0000000
+
+ Note: Tensor is right-handed
+
+ Contributions:
+ V(El )       0.7854455       0.7202449  -1.5056904
+ V(Nuc)      -0.9385745      -0.8951044   1.8336789
+
+ Quadrupole tensor eigenvalues (in MHz;Q= 0.0029 I=  1.0)
+  e**2qQ            =     0.220241 MHz 
+  e**2qQ/(4I*(2I-1))=     0.055060 MHz 
+  eta               =     0.066254
+  NOTE: the diagonal representation of the SH term I*Q*I = e**2qQ/(4I(2I-1))*[-(1-eta),-(1+eta),2]
+
+ RHO(0)=      0.464439904 a.u.**-3
+
+
+Hyperfine and quadrupole coupling calculation done in   0.1 sec 
+
+Maximum memory used throughout the entire PROP-calculation: 6.0 MB
+
+--------------------------------
+SUGGESTED CITATIONS FOR THIS RUN
+--------------------------------
+
+Below you find a list of papers that are relevant to this ORCA run
+We neither can nor want to force you to cite these papers, but we appreciate if you do
+You receive ORCA, which is the product of decades of hard work by many enthusiastic individuals, for free
+The only thing we kindly ask in return is that you cite our papers,
+We deeply appreciate it, if you show your appreciation for ORCA by not just citing the generic ORCA reference.
+
+Please note that relegating all ORCA citations to the supporting information does *not* help us.
+SI sections are not indexed - citations you put there will not count into any citation statistics
+But we need these citations in order to attract the funding resources that allow us to do what we are doing
+
+Therefore, if you are a happy ORCA user, please consider citing a few of the papers listed below in the main body of your paper
+
+In addition to the list printed below, the program has created the file NH2_A.bibtex that contains the list in bibtex format
+You can import this file easily into all common literature databanks and citation aid programs
+
+
+List of essential papers. We consider these as the minimum necessary citations
+
+  1. Neese,F.
+     Software update: the ORCA program system, version 5.0
+     WIRES Comput. Molec. Sci., 2022 12(1)e1606
+     doi.org/10.1002/wcms.1606
+
+List of papers to cite with high priority. The work reported in these papers was absolutely
+necessary for this run to complete.
+Our perspective: the developers of density functionals and basis sets usually get cited in chemistry papers
+Good! But without the algorithms to do something with them, the functionals or basis sets would not do anything.
+Hence, in our opinion, the algorithm design and method developments papers are equally worthy of getting cited
+
+  1. Neese,F.
+     Prediction and interpretation of the Fe-57 isomer shift in Mössbauer spectra by density functional theory
+     Inorg. Chim. Acta, 2002 337 181-192
+     doi.org/10.1016/s0020-1693(02)01031-9
+  2. Neese,F.
+     An improvement of the resolution of the identity approximation for the formation of the Coulomb matrix
+     J. Comp. Chem., 2003 24(14)1740-1747
+     doi.org/10.1002/jcc.10318
+  3. Neese,F.
+     Metal and ligand hyperfine couplings in transition metal complexes: The effect of spin-orbit coupling as studied by coupled perturbed Kohn-Sham theory
+     J. Chem. Phys., 2003 118(9)3939-3948
+     doi.org/10.1063/1.1540619
+  4. Neese,F.; Wennmohs,F.; Hansen,A.; Becker,U.
+     Efficient, approximate and parallel Hartree-Fock and hybrid DFT calculations. A 'chain-of-spheres' algorithm for the Hartree-Fock exchange
+     Chem. Phys., 2009 356(1-3)98-109
+     doi.org/10.1016/j.chemphys.2008.10.036
+  5. Helmich-Paris,B.; de Souza,B.; Neese,F.; Izsák,R.
+     An improved chain of spheres for exchange algorithm
+     J. Chem. Phys., 2021 155 104109
+     doi.org/doi: 10.1063/5.0058766.
+  6. Neese,F.
+     The SHARK Integral Generation and Digestion System
+     J. Comp. Chem., 2022  1-16
+     doi.org/10.1002/jcc.26942
+
+List of suggested additional citations. These are papers that are important in the 'surrounding' of 
+of this run, or papers that preceded the highly important papers. If you like your results we are grateful for a citation.
+
+  1. Neese,F.
+     Theoretical study of ligand superhyperfine structure. Application to Cu(II) complexes
+     J. Phys. Chem. A, 2001 105(17)4290-4299
+     doi.org/10.1021/jp003254f
+  2. Römelt,M.; Ye,S.F.; Neese,F.
+     Calibration of Modern Density Functional Theory Methods for the Prediction of Fe-57 Mössbauer Isomer Shifts: Meta-GGA and Double-Hybrid Functionals
+     Inorg. Chem., 2009 48 784-785
+     doi.org/10.1021/ic801535v
+  3. Izsak,R.; Neese,F.
+     An overlap fitted chain of spheres exchange method
+     J. Chem. Phys., 2011 135 144105
+     doi.org/10.1063/1.3646921
+  4. Izsak,R.; Hansen,A.; Neese,F.
+     The resolution of identity and chain of spheres approximations for the LPNO-CCSD singles Fock term
+     Molec. Phys., 2012 110 2413-2417
+     doi.org/10.1080/00268976.2012.687466
+  5. Neese,F.
+     The ORCA program system
+     WIRES Comput. Molec. Sci., 2012 2(1)73-78
+     doi.org/10.1002/wcms.81
+  6. Izsak,R.; Neese,F.; Klopper,W.
+     Robust fitting techniques in the chain of spheres approximation to the Fock exchange: The role of the complementary space
+     J. Chem. Phys., 2013 139 
+     doi.org/10.1063/1.4819264
+  7. Neese,F.
+     Software update: the ORCA program system, version 4.0
+     WIRES Comput. Molec. Sci., 2018 8(1)1-6
+     doi.org/10.1002/wcms.1327
+  8. Neese,F.; Wennmohs,F.; Becker,U.; Riplinger,C.
+     The ORCA quantum chemistry program package
+     J. Chem. Phys., 2020 152 Art. No. L224108
+     doi.org/10.1063/5.0004608
+
+List of optional additional citations
+
+  1. Neese,F.
+     Approximate second-order SCF convergence for spin unrestricted wavefunctions
+     Chem. Phys. Lett., 2000 325(1-3)93-98
+     doi.org/10.1016/s0009-2614(00)00662-x
+
+Timings for individual modules:
+
+Sum of individual times          ...        3.465 sec (=   0.058 min)
+Startup calculation              ...        0.318 sec (=   0.005 min)   9.2 %
+SCF iterations                   ...        2.034 sec (=   0.034 min)  58.7 %
+Property integrals               ...        0.317 sec (=   0.005 min)   9.1 %
+SCF Response                     ...        0.579 sec (=   0.010 min)  16.7 %
+Property calculations            ...        0.217 sec (=   0.004 min)   6.3 %
+                             ****ORCA TERMINATED NORMALLY****
+TOTAL RUN TIME: 0 days 0 hours 0 minutes 3 seconds 550 msec

--- a/examples/data/NH2_A.property.txt
+++ b/examples/data/NH2_A.property.txt
@@ -1,0 +1,266 @@
+*************************************************
+******************* ORCA 6.0.0 ******************
+*************************************************
+$Calculation_Status
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &VERSION [&Type "String"] "6.0.0"
+   &PROGNAME [&Type "String"] "LeanSCF"
+   &STATUS [&Type "String"] "NORMAL TERMINATION"
+$End
+$Geometry
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &NATOMS [&Type "Integer"] 3
+   &NCORELESSECP [&Type "Integer"] 0
+   &NGHOSTATOMS [&Type "Integer"] 0
+   &CartesianCoordinates [&Type "Coordinates", &Dim(3,4), &Units "Bohr"] 
+              N     -0.028326008840   -0.035798741558    0.000000000000
+              H      1.950156462611    0.017171534188    0.000000000000
+              H     -0.431915437112    1.901805753410    0.000000000000
+$End
+$SCF_Energy
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &SCF_ENERGY [&Type "Double"]      -5.5875432645867889e+01
+$End
+$DFT_Energy
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &NALPHAEL [&Type "Integer"] 5
+   &NBETAEL [&Type "Integer"] 4
+   &NTOTALEL [&Type "Integer"] 9
+   &EEXCHANGE [&Type "Double"]      -5.7625375351114254e+00
+   &ECORR [&Type "Double"]      -3.3219807346636804e-01
+   &ECNL [&Type "Double"]       0.0000000000000000e+00
+   &EXC [&Type "Double"]      -6.0947356085777935e+00
+   &EEMBED [&Type "Double"]       0.0000000000000000e+00
+   &FINALEN [&Type "Double"]      -5.5875432645867889e+01  "No Van der Waals correction"
+$End
+$Mulliken_Population_Analysis
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &NATOMS [&Type "Integer"] 3
+   &ATNO [&Type "ArrayOfIntegers", &Dim (3,1)] 
+                                                         0
+
+0                                                        7
+1                                                        1
+2                                                        1
+   &ATOMICCHARGES [&Type "ArrayOfDoubles", &Dim (3,1)] 
+                                                         0
+
+0                                     -4.4646443652955536e-01
+1                                      2.2320574568662899e-01
+2                                      2.2325869084291061e-01
+$End
+$Loewdin_Population_Analysis
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &NATOMS [&Type "Integer"] 3
+   &ATNO [&Type "ArrayOfIntegers", &Dim (3,1)] 
+                                                         0
+
+0                                                        7
+1                                                        1
+2                                                        1
+   &ATOMICCHARGES [&Type "ArrayOfDoubles", &Dim (3,1)] 
+                                                         0
+
+0                                     -9.8678715120507299e-02
+1                                      4.9337940023147508e-02
+2                                      4.9340775097344469e-02
+$End
+$Mayer_Population_Analysis
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &NATOMS [&Type "Integer"] 3 "Total number of atoms"
+   &BONDTHRESH [&Type "Double"]       1.0000000000000001e-01  "The threshold for printing"
+   &NBONDORDERSPRINT [&Type "Integer"] 2 "The number of bond orders larger than threshold"
+   &BONDORDERS [&Type "ArrayOfDoubles", &Dim (2,1)] "The bond orders"
+                                                         0
+
+0                                      9.4254718314191943e-01
+1                                      9.4252946149906192e-01
+   &COMPONENTS [&Type "ArrayOfIntegers", &Dim (2,4)] "The indices and atomic numbers of the bonding atoms"
+                                                         0                           1                           2                           3
+
+0                                                        0                           7                           1                           1
+1                                                        0                           7                           2                           1
+   &ATNO [&Type "ArrayOfIntegers", &Dim (3,1)] "Atomic number of the elements"
+                                                         0
+
+0                                                        7
+1                                                        1
+2                                                        1
+   &NA [&Type "ArrayOfDoubles", &Dim (3,1)] "Mulliken gross atomic population"
+                                                         0
+
+0                                      7.4464644365295616e+00
+1                                      7.7679425431337090e-01
+2                                      7.7674130915708950e-01
+   &ZA [&Type "ArrayOfDoubles", &Dim (3,1)] "Total nuclear charge"
+                                                         0
+
+0                                      7.0000000000000000e+00
+1                                      1.0000000000000000e+00
+2                                      1.0000000000000000e+00
+   &QA [&Type "ArrayOfDoubles", &Dim (3,1)] "Mulliken gross atomic charge"
+                                                         0
+
+0                                     -4.4646443652956158e-01
+1                                      2.2320574568662910e-01
+2                                      2.2325869084291050e-01
+   &VA [&Type "ArrayOfDoubles", &Dim (3,1)] "Mayer's total valence"
+                                                         0
+
+0                                      2.8437054130004271e+00
+1                                      9.5608217590320088e-01
+2                                      9.5606397611487148e-01
+   &BVA [&Type "ArrayOfDoubles", &Dim (3,1)] "Mayer's bonded valence"
+                                                         0
+
+0                                      1.8850766446409812e+00
+1                                      9.5471357548354685e-01
+2                                      9.5469585384068933e-01
+   &FA [&Type "ArrayOfDoubles", &Dim (3,1)] "Mayer's free valence"
+                                                         0
+
+0                                      9.5862876835944577e-01
+1                                      1.3686004196539932e-03
+2                                      1.3681222741821104e-03
+$End
+$Calculation_Info
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &MULT [&Type "Integer"] 2
+   &CHARGE [&Type "Integer"] 0
+   &NUMOFATOMS [&Type "Integer"] 3
+   &NUMOFELECTRONS [&Type "Integer"] 9
+   &NUMOFFCELECTRONS [&Type "Integer"] 1
+   &NUMOFCORRELECTRONS [&Type "Integer"] 0
+   &NUMOFBASISFUNCTS [&Type "Integer"] 62
+   &NUMOFAUXCBASISFUNCTS [&Type "Integer"] 0
+   &NUMOFAUXJBASISFUNCTS [&Type "Integer"] 71
+   &NUMOFAUXJKBASISFUNCTS [&Type "Integer"] 0
+   &NUMOFCABSBASISFUNCTS [&Type "Integer"] 0
+   &TOTALENERGY [&Type "Double"]      -5.5875432645867889e+01  "Hartrees"
+$End
+$SCF_Dipole_Moment
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &METHOD [&Type "String"] "SCF"
+   &LEVEL [&Type "String"] "Relaxed density"
+   &MULT [&Type "Integer"] 2
+   &STATE [&Type "Integer"] -1
+   &IRREP [&Type "Integer"] 0
+   &NATOMS [&Type "Integer"] 3
+   &DODIPOLEATOM [&Type "Boolean"] false
+   &DIPOLEELECCONTRIB [&Type "ArrayOfDoubles", &Dim (3,1)] "Electronic contribution"
+                                                         0
+
+0                                     -2.1763465346726316e-01
+1                                     -2.7503997505951189e-01
+2                                     -7.0904186661932165e-09
+   &DIPOLENUCCONTRIB [&Type "ArrayOfDoubles", &Dim (3,1)] "Nuclear contribution"
+                                                         0
+
+0                                      6.8321048137927221e-01
+1                                      8.6353898965393461e-01
+2                                      0.0000000000000000e+00
+   &DIPOLETOTAL [&Type "ArrayOfDoubles", &Dim (3,1)] "Total"
+                                                         0
+
+0                                      4.6557582791200902e-01
+1                                      5.8849901459442266e-01
+2                                     -7.0904186661932165e-09
+   &DIPOLEMAGNITUDE [&Type "Double", &Units "a.u."]       7.5039452404355877e-01
+$End
+$SCF_A_Tensor
+   &GeometryIndex 1
+   &ListStatus       OUT
+   &METHOD [&Type "String"] "SCF"
+   &LEVEL [&Type "String"] "Relaxed density"
+   &MULT [&Type "Integer"] 2
+   &STATE [&Type "Integer"] -1
+   &IRREP [&Type "Integer"] 0
+   &NUMOFNUCS [&Type "Integer"] 3 "Number of active nuclei"
+   &ACTIVENUCS [&Type "ArrayOfIntegers", &Dim (3,1)] "active nuclei indices"
+                                                         0
+
+0                                                        0
+1                                                        1
+2                                                        2
+   &NUC [&Type "Integer"] 0 "Index of the nuclei"
+   &ELEM [&Type "Integer"] 7 "Atomic number of the nuclei"
+   &ISOTOPE [&Type "Double"]       1.4000000000000000e+01  "Atomic mass"
+   &I [&Type "Double"]       1.0000000000000000e+00  "Spin of the nuclei"
+   &PFAC [&Type "Double"]       3.8567696858543279e+01  "Prefactor PFAC=ge*gN*be*bN (in MHz)"
+   &ARAW [&Type "ArrayOfDoubles", &Dim (3,3)] "Raw tensor"
+                                                         0                           1                           2
+
+0                                     -1.5705078047539592e+01        -6.7203240419041743e-01        -1.0364688718168733e-06
+1                                     -6.7204754570860137e-01        -1.6022837137109558e+01        -7.4611198058834007e-07
+2                                     -1.0195937183896051e-06        -8.0113818294226217e-07         1.1722063781580660e+02
+   &AEIGENVALUES [&Type "ArrayOfDoubles", &Dim (3,1)] "Eigenvalues"
+                                                         0
+
+0                                     -1.5173392289345788e+01
+1                                     -1.6554522895303375e+01
+2                                      1.1722063781580663e+02
+   &AISO [&Type "Double"]       2.8497574210385821e+01
+   &ORIENTATION [&Type "ArrayOfDoubles", &Dim (3,3)] "Eigenvectors"
+                                                         0                           1                           2
+
+0                                      7.8424300169598160e-01         6.2045379706379145e-01        -7.7692422237460718e-09
+1                                     -6.2045379706379156e-01         7.8424300169598138e-01        -5.5604272088947976e-09
+2                                      2.6429856673981846e-09         9.1811819630472544e-09         1.0000000000000000e+00
+   &NUC [&Type "Integer"] 1 "Index of the nuclei"
+   &ELEM [&Type "Integer"] 1 "Atomic number of the nuclei"
+   &ISOTOPE [&Type "Double"]       1.0000000000000000e+00  "Atomic mass"
+   &I [&Type "Double"]       5.0000000000000000e-01  "Spin of the nuclei"
+   &PFAC [&Type "Double"]       5.3355139537259129e+02  "Prefactor PFAC=ge*gN*be*bN (in MHz)"
+   &ARAW [&Type "ArrayOfDoubles", &Dim (3,3)] "Raw tensor"
+                                                         0                           1                           2
+
+0                                     -8.8950860352322580e-01         1.7281456625656386e-01         6.5994114315180385e-07
+1                                      8.4950845188324575e-02        -1.1433846966534203e+02        -2.5323672034183965e-07
+2                                      6.8163432116132913e-07        -2.4044491981988507e-07        -6.9612348410000735e+01
+   &AEIGENVALUES [&Type "ArrayOfDoubles", &Dim (3,1)] "Eigenvalues"
+                                                         0
+
+0                                     -8.8937919956486799e-01
+1                                     -6.9612348410000735e+01
+2                                     -1.1433859906930039e+02
+   &AISO [&Type "Double"]      -6.1613442226288669e+01
+   &ORIENTATION [&Type "ArrayOfDoubles", &Dim (3,3)] "Eigenvectors"
+                                                         0                           1                           2
+
+0                                     -9.9999883981598281e-01        -9.5886054599846604e-09        -1.5232749877020534e-03
+1                                     -1.5232749877018836e-03        -5.6919539510015139e-09         9.9999883981598292e-01
+2                                     -9.5972647465225731e-09         9.9999999999999989e-01         5.6773412644233769e-09
+   &NUC [&Type "Integer"] 2 "Index of the nuclei"
+   &ELEM [&Type "Integer"] 1 "Atomic number of the nuclei"
+   &ISOTOPE [&Type "Double"]       1.0000000000000000e+00  "Atomic mass"
+   &I [&Type "Double"]       5.0000000000000000e-01  "Spin of the nuclei"
+   &PFAC [&Type "Double"]       5.3355139537259129e+02  "Prefactor PFAC=ge*gN*be*bN (in MHz)"
+   &ARAW [&Type "ArrayOfDoubles", &Dim (3,3)] "Raw tensor"
+                                                         0                           1                           2
+
+0                                     -1.0837451256815292e+02        -2.5325950168764713e+01         1.7538608256950023e-07
+1                                     -2.5238106444870038e+01        -6.8187602366883047e+00         4.4857627448404073e-07
+2                                      1.8695478136767992e-07         4.1209303579343125e-07        -6.9595960233256406e+01
+   &AEIGENVALUES [&Type "ArrayOfDoubles", &Dim (3,1)] "Eigenvalues"
+                                                         0
+
+0                                     -8.7298949591386954e-01
+1                                     -6.9595960233256449e+01
+2                                     -1.1432028330892740e+02
+   &AISO [&Type "Double"]      -6.1596411012699242e+01
+   &ORIENTATION [&Type "ArrayOfDoubles", &Dim (3,3)] "Eigenvectors"
+                                                         0                           1                           2
+
+0                                      2.2926974218546911e-01        -7.2730312033771783e-09         9.7336292579808525e-01
+1                                     -9.7336292579808514e-01         4.2054779338149189e-09         2.2926974218546914e-01
+2                                     -5.7609422949425334e-09        -1.0000000000000002e+00        -6.1151100898875475e-09
+$End

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -1,7 +1,9 @@
 import radicalpy as rp
 
 print("Read from .out file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca_hyperfine("./examples/data/NH2_A.out")
+indices, isotopes, hfc_matrices = rp.utils.read_orca_hyperfine(
+    "./examples/data/NH2_A.out"
+)
 nuclei = [
     rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
     for isotope, hfc_matrix in zip(isotopes, hfc_matrices)

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -1,0 +1,20 @@
+import radicalpy as rp
+
+print("Read from .out file")
+indices, isotopes, hfc_matrices = rp.utils.read_orca("data/NH2_A.out")
+nuclei = [
+    rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
+    for isotope, hfc_matrix in zip(isotopes, hfc_matrices)
+]
+molecule = rp.simulation.Molecule("mol1", nuclei)
+print(molecule)
+
+
+print("\nRead from .property.txt file")
+indices, isotopes, hfc_matrices = rp.utils.read_orca("data/NH2_A.property.txt")
+nuclei = [
+    rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
+    for isotope, hfc_matrix in zip(isotopes, hfc_matrices)
+]
+molecule = rp.simulation.Molecule("mol1", nuclei)
+print(molecule)

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -1,7 +1,7 @@
 import radicalpy as rp
 
 print("Read from .out file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca("data/NH2_A.out")
+indices, isotopes, hfc_matrices = rp.utils.read_orca("./examples/data/NH2_A.out")
 nuclei = [
     rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
     for isotope, hfc_matrix in zip(isotopes, hfc_matrices)
@@ -11,7 +11,7 @@ print(molecule)
 
 
 print("\nRead from .property.txt file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca("data/NH2_A.property.txt")
+indices, isotopes, hfc_matrices = rp.utils.read_orca("./examples/data/NH2_A.property.txt")
 nuclei = [
     rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
     for isotope, hfc_matrix in zip(isotopes, hfc_matrices)

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -13,7 +13,7 @@ print(molecule)
 
 
 print("\nRead from .property.txt file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca(
+indices, isotopes, hfc_matrices = rp.utils.read_orca_hyperfine(
     "./examples/data/NH2_A.property.txt"
 )
 nuclei = [

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -11,7 +11,9 @@ print(molecule)
 
 
 print("\nRead from .property.txt file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca("./examples/data/NH2_A.property.txt")
+indices, isotopes, hfc_matrices = rp.utils.read_orca(
+    "./examples/data/NH2_A.property.txt"
+)
 nuclei = [
     rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
     for isotope, hfc_matrix in zip(isotopes, hfc_matrices)

--- a/examples/read_orca.py
+++ b/examples/read_orca.py
@@ -1,7 +1,7 @@
 import radicalpy as rp
 
 print("Read from .out file")
-indices, isotopes, hfc_matrices = rp.utils.read_orca("./examples/data/NH2_A.out")
+indices, isotopes, hfc_matrices = rp.utils.read_orca_hyperfine("./examples/data/NH2_A.out")
 nuclei = [
     rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist())
     for isotope, hfc_matrix in zip(isotopes, hfc_matrices)

--- a/radicalpy/utils.py
+++ b/radicalpy/utils.py
@@ -5,7 +5,7 @@
 .. todo:: Add module docstring.
 """
 import argparse
-import sys
+import re
 from pathlib import Path
 from typing import Tuple
 
@@ -468,3 +468,364 @@ def yield_anisotropy(
     yield_av = spherical_average(product_yield, theta, phi)
     gamma = delta_phi / yield_av
     return delta_phi, gamma
+
+
+def read_orca(
+    path: Path | str, version: int = 6
+) -> tuple[list[int], list[str], list[np.ndarray]]:
+    """Read ORCA output file.
+
+    Args:
+        path (Path): The path to the ORCA output file. Both .out and .property.txt are supported.
+
+    Returns:
+        tuple[list[int], list[str], list[np.ndarray]]: The list of nucleus indices, isotopes, and HFC matrices. Note that indices starts from 0 (same as ORCA).
+
+    Examples:
+       >>> import radicalpy as rp
+       >>> indices, isotopes, hfc_matrices = rp.utils.read_orca("orca.out") # or rp.utils.read_orca("orca.property.txt")
+       >>> nuclei = [rp.data.Nucleus.fromisotope(isotope, hfc_matrix.tolist()) for isotope, hfc_matrix in zip(isotopes, hfc_matrices)]
+       >>> molecule = rp.simulation.Molecule("mol1", nuclei)
+       Molecule: mol1
+       Nuclei:
+       14N(19337792.0, 3, 1.017 <anisotropic available>)
+       1H(267522187.44, 2, -2.199 <anisotropic available>)
+       1H(267522187.44, 2, -2.198 <anisotropic available>)
+       Radical: E(-176085963023.0, 2, 0.0 <anisotropic not available>)
+
+    """
+    if isinstance(path, str):
+        path = Path(path)
+    if version == 6:
+        if path.name.endswith(".property.txt"):
+            indices, isotopes, hfc_matrices = _read_orca_6_property_txt(path)
+        else:
+            indices, isotopes, hfc_matrices = _read_orca_6_out(path)
+    else:
+        raise NotImplementedError(f"Version {version} is not supported")
+
+    for index, isotope, hfc_matrix in zip(indices, isotopes, hfc_matrices, strict=True):
+        print(
+            f"Nucleus {index} (starts from 0) isotope {isotope} HFC matrix [mT]:\n {hfc_matrix}\n"
+        )
+
+    return indices, isotopes, hfc_matrices
+
+
+def _read_orca_6_out(path: Path) -> tuple[list[int], list[str], list[np.ndarray]]:
+    with open(path, "r") as file:
+        lines = file.readlines()
+
+    is_epr_block = False
+    is_hfc_matrix_block = False
+    n_nuclei = -1
+    indices = []
+    isotopes = []
+    hfc_matrices = []
+    # Extract 3 from "ELECTRIC AND MAGNETIC HYPERFINE STRUCTURE (3 nuclei)"
+    NUCLEI_REGEX = re.compile(
+        r"""\(          # opening parenthesis
+            \s*         # optional spaces
+            (\d+)       # ← capture the integer
+            \s*         # optional spaces
+            nucle(?:i|us)  # 'nuclei' or 'nucleus', case‑insensitive
+            \s*         # optional spaces
+            \)          # closing parenthesis
+        """,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    # Extract 0 from "Nucleus   0N"
+    INDEX_REGEX = re.compile(
+        r"Nucleus\s+(\d+)\w+",
+        flags=re.IGNORECASE,
+    )
+    # Extract N from  "Nucleus   0N"
+    ELEM_REGEX = re.compile(
+        r"Nucleus\s+\d+(\w+)",
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    ISOTOPE_REGEX = re.compile(
+        r"Isotope=(\s*\d+)",
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("ELECTRIC AND MAGNETIC HYPERFINE STRUCTURE"):
+            is_epr_block = True
+            # line is like "ELECTRIC AND MAGNETIC HYPERFINE STRUCTURE (3 nuclei)"
+            # we need to extract the number of nuclei by re.search
+            n_nuclei = int(NUCLEI_REGEX.search(line).group(1))
+            i += 1
+            continue
+        if not is_epr_block:
+            i += 1
+            continue
+        if line.startswith(" Nucleus"):
+            # line is like "Nucleus   0N : A  : Isotope=   14 I=  1.0 P= 38.5677 MHz/au**3"
+            # we need to extract the nucleus name, isotope.
+            split_items = line.split(":")
+            # split_items[0] is "Nucleus   0N"
+            indices.append(int(INDEX_REGEX.search(split_items[0]).group(1)))
+            element = ELEM_REGEX.search(split_items[0]).group(1)
+            # split_items[1] is "A"
+            if split_items[1].strip() != "A":
+                raise ValueError(f"Unsupported format: {line}")
+            # split_items[2] is "Isotope=   14 I=  1.0 P= 38.5677 MHz/au**3"
+            isotope = int(ISOTOPE_REGEX.search(split_items[2]).group(1))
+            isotopes.append(f"{isotope}{element}")
+        elif line.startswith(" Total HFC matrix (all values in MHz)"):
+            is_hfc_matrix_block = True
+            i += 2
+            continue
+        if is_hfc_matrix_block:
+            AxxAxyAxz = [MHz_to_mT(float(x)) for x in line.split()]
+            i += 1
+            AyxAyyAyz = [MHz_to_mT(float(x)) for x in lines[i].split()]
+            i += 1
+            AzxAzyAzz = [MHz_to_mT(float(x)) for x in lines[i].split()]
+            i += 1
+            A = np.array([AxxAxyAxz, AyxAyyAyz, AzxAzyAzz])
+            # When SOC is included, A is not always symmetric.
+            # np.testing.assert_allclose(A, A.T, atol=1e-6)
+            hfc_matrices.append(A)
+            is_hfc_matrix_block = False
+            if len(hfc_matrices) == n_nuclei:
+                break
+        i += 1
+    if len(indices) != n_nuclei:
+        raise ValueError(f"Number of nuclei mismatch: {len(indices)} != {n_nuclei}")
+    if len(isotopes) != n_nuclei:
+        raise ValueError(f"Number of isotopes mismatch: {len(isotopes)} != {n_nuclei}")
+    if len(hfc_matrices) != n_nuclei:
+        raise ValueError(
+            f"Number of HFC matrices mismatch: {len(hfc_matrices)} != {n_nuclei}"
+        )
+    return indices, isotopes, hfc_matrices
+
+
+def _read_orca_6_property_txt(
+    path: Path,
+) -> tuple[list[int], list[str], list[np.ndarray]]:
+    with open(path, "r") as file:
+        lines = file.readlines()
+    is_scf_a_tensor_block = False
+    indices = []
+    isotopes = []
+    hfc_matrices = []
+    # Extract 3 from  "   &NUMOFNUCS [&Type "Integer"] 3 "Number of active nuclei"
+    NUCLEI_REGEX = re.compile(
+        r"""
+        &NUMOFNUCS\s*\[&Type\s*"Integer"\]\s*(\d+)\s*"Number\s*of\s*active\s*nucle(?:i|us)"
+        """,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    # Extract 0 from "   &NUC [&Type "Integer"] 0 "Index of the nuclei"
+    NUCLEI_INDEX_REGEX = re.compile(
+        r"""
+        &NUC\s*\[&Type\s*"Integer"\]\s*(\d+)\s*"Index\s*of\s*the\s*nuclei"
+        """,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    # Extract 7 from "   &ELEM [&Type "Integer"] 7 "Atomic number of the nuclei"
+    ELEM_REGEX = re.compile(
+        r"""
+        &ELEM\s*\[&Type\s*"Integer"\]\s*(\d+)\s*"Atomic\s*number\s*of\s*the\s*nucle(?:i|us)"
+        """,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    # Extract 14 from "   &ISOTOPE [&Type "Double"]       1.4000000000000000e+01  "Atomic mass"
+    ISOTOPE_REGEX = re.compile(
+        r"""
+        &ISOTOPE\s*\[&Type\s*"Double"\]\s*([0-9.e+-]+)\s*"Atomic\s*mass"
+        """,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+
+    # This dictionary may be better to be a shared constant.
+    elem_dict = {
+        1: "H",
+        2: "He",
+        3: "Li",
+        4: "Be",
+        5: "B",
+        6: "C",
+        7: "N",
+        8: "O",
+        9: "F",
+        10: "Ne",
+        11: "Na",
+        12: "Mg",
+        13: "Al",
+        14: "Si",
+        15: "P",
+        16: "S",
+        17: "Cl",
+        18: "Ar",
+        19: "K",
+        20: "Ca",
+        21: "Sc",
+        22: "Ti",
+        23: "V",
+        24: "Cr",
+        25: "Mn",
+        26: "Fe",
+        27: "Co",
+        28: "Ni",
+        29: "Cu",
+        30: "Zn",
+        31: "Ga",
+        32: "Ge",
+        33: "As",
+        34: "Se",
+        35: "Br",
+        36: "Kr",
+        37: "Rb",
+        38: "Sr",
+        39: "Y",
+        40: "Zr",
+        41: "Nb",
+        42: "Mo",
+        43: "Tc",
+        44: "Ru",
+        45: "Rh",
+        46: "Pd",
+        47: "Ag",
+        48: "Cd",
+        49: "In",
+        50: "Sn",
+        51: "Sb",
+        52: "Te",
+        53: "I",
+        54: "Xe",
+        55: "Cs",
+        56: "Ba",
+        57: "La",
+        58: "Ce",
+        59: "Pr",
+        60: "Nd",
+        61: "Pm",
+        62: "Sm",
+        63: "Eu",
+        64: "Gd",
+        65: "Tb",
+        66: "Dy",
+        67: "Ho",
+        68: "Er",
+        69: "Tm",
+        70: "Yb",
+        71: "Lu",
+        72: "Hf",
+        73: "Ta",
+        74: "W",
+        75: "Re",
+        76: "Os",
+        77: "Ir",
+        78: "Pt",
+        79: "Au",
+        80: "Hg",
+        81: "Tl",
+        82: "Pb",
+        83: "Bi",
+        84: "Po",
+        85: "At",
+        86: "Rn",
+        87: "Fr",
+        88: "Ra",
+        89: "Ac",
+        90: "Th",
+        91: "Pa",
+        92: "U",
+        93: "Np",
+        94: "Pu",
+        95: "Am",
+        96: "Cm",
+        97: "Bk",
+        98: "Cf",
+        99: "Es",
+        100: "Fm",
+        101: "Md",
+        102: "No",
+        103: "Lr",
+        104: "Rf",
+        105: "Db",
+        106: "Sg",
+        107: "Bh",
+        108: "Hs",
+        109: "Mt",
+        110: "Ds",
+        111: "Rg",
+        112: "Cn",
+        113: "Nh",
+        114: "Fl",
+        115: "Mc",
+        116: "Lv",
+        117: "Ts",
+        118: "Og",
+    }
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("$SCF_A_Tensor"):
+            is_scf_a_tensor_block = True
+            i += 1
+            continue
+        if not is_scf_a_tensor_block:
+            i += 1
+            continue
+        if is_scf_a_tensor_block and line.startswith("$End"):
+            is_scf_a_tensor_block = False
+            break
+
+        if line.strip().startswith('&NUMOFNUCS [&Type "Integer"]'):
+            # line is like    &NUMOFNUCS [&Type "Integer"] 3 "Number of active nuclei"
+            n_nuclei = int(NUCLEI_REGEX.search(line).group(1))
+            i += 1
+            continue
+
+        if line.strip().startswith('&NUC [&Type "Integer"]'):
+            # line is like    &NUC [&Type "Integer"] 0 "Index of the nuclei"
+            nucleus_index = int(NUCLEI_INDEX_REGEX.search(line).group(1))
+            indices.append(nucleus_index)
+            i += 1
+            continue
+
+        if line.strip().startswith('&ELEM [&Type "Integer"]'):
+            # line is like    &ELEM [&Type "Integer"] 7 "Atomic number of the nuclei"
+            element = int(ELEM_REGEX.search(line).group(1))
+            i += 1
+            continue
+
+        if line.strip().startswith('&ISOTOPE [&Type "Double"]'):
+            #    &ISOTOPE [&Type "Double"]       1.4000000000000000e+01  "Atomic mass"
+            isotope = int(float(ISOTOPE_REGEX.search(line).group(1)))
+            isotopes.append(f"{isotope}{elem_dict[element]}")
+            i += 1
+            del nucleus_index
+            del element
+            del isotope
+            continue
+
+        if line.strip().startswith("&ARAW"):
+            i += 3
+            AxxAxyAxz = [MHz_to_mT(float(x)) for x in lines[i].split()[1:]]
+            i += 1
+            AyxAyyAyz = [MHz_to_mT(float(x)) for x in lines[i].split()[1:]]
+            i += 1
+            AzxAzyAzz = [MHz_to_mT(float(x)) for x in lines[i].split()[1:]]
+            A = np.array([AxxAxyAxz, AyxAyyAyz, AzxAzyAzz])
+            hfc_matrices.append(A)
+            i += 1
+            continue
+        i += 1
+
+    if len(indices) != n_nuclei:
+        raise ValueError(f"Number of nuclei mismatch: {len(indices)} != {n_nuclei}")
+    if len(isotopes) != n_nuclei:
+        raise ValueError(f"Number of isotopes mismatch: {len(isotopes)} != {n_nuclei}")
+    if len(hfc_matrices) != n_nuclei:
+        raise ValueError(
+            f"Number of HFC matrices mismatch: {len(hfc_matrices)} != {n_nuclei}"
+        )
+    return indices, isotopes, hfc_matrices

--- a/radicalpy/utils.py
+++ b/radicalpy/utils.py
@@ -470,7 +470,7 @@ def yield_anisotropy(
     return delta_phi, gamma
 
 
-def read_orca(
+def read_orca_hyperfine(
     path: Path | str, version: int = 6
 ) -> tuple[list[int], list[str], list[np.ndarray]]:
     """Read ORCA output file.
@@ -498,9 +498,9 @@ def read_orca(
         path = Path(path)
     if version == 6:
         if path.name.endswith(".property.txt"):
-            indices, isotopes, hfc_matrices = _read_orca_6_property_txt(path)
+            indices, isotopes, hfc_matrices = _hyperfine_from_orca6_property_txt(path)
         else:
-            indices, isotopes, hfc_matrices = _read_orca_6_out(path)
+            indices, isotopes, hfc_matrices = _hyperfine_from_orca6_out(path)
     else:
         raise NotImplementedError(f"Version {version} is not supported")
 
@@ -512,7 +512,9 @@ def read_orca(
     return indices, isotopes, hfc_matrices
 
 
-def _read_orca_6_out(path: Path) -> tuple[list[int], list[str], list[np.ndarray]]:
+def _hyperfine_from_orca6_out(
+    path: Path,
+) -> tuple[list[int], list[str], list[np.ndarray]]:
     with open(path, "r") as file:
         lines = file.readlines()
 
@@ -604,7 +606,7 @@ def _read_orca_6_out(path: Path) -> tuple[list[int], list[str], list[np.ndarray]
     return indices, isotopes, hfc_matrices
 
 
-def _read_orca_6_property_txt(
+def _hyperfine_from_orca6_property_txt(
     path: Path,
 ) -> tuple[list[int], list[str], list[np.ndarray]]:
     with open(path, "r") as file:


### PR DESCRIPTION
## Summary
- Implemented `read_orca_hyperfine` to parse hyperfine A tensors from ORCA 6.0.x outputs.
- Supports both the standard output file and the `.property.txt` file.
- Added example inputs at `examples/data/NH2_A.out` and `examples/data/NH2_A.property.txt` (please remove if you prefer to avoid bundling data files).

- Included an atomic-number dictionary → element/isotope mapping to extract notations like 14N. This mapping is currently inside `_hyperfine_from_orca6_property_txt`; if preferred, please relocate it to a shared resource (e.g., `radicalpy/data_files`).

## Version handling
- ORCA 5.x uses `_property.txt` (underscore), while ORCA 6.x uses `.property.txt.`
- The parser accepts a version argument and also attempts auto-detection from file contents/filename to remain robust to future changes.

## Why this name?
- Chose read_orca_**hyperfine** explicitly because ORCA can also output D tensors, g-values, etc.; this function currently focuses on A tensors.