### PR TITLE
CRITICAL CHANGE factor gamma_mT to |gamma_mT| to avoid confusion

### DIFF
--- a/radicalpy/estimations.py
+++ b/radicalpy/estimations.py
@@ -395,9 +395,9 @@ def dipolar_interaction_point_dipole(r12: tuple[float, float, float]) -> np.ndar
     rx, ry, rz = r12_unit
     mat = np.array(
         [
-            [3 * rx * rx - 1.0, 2 * rx * ry, 2 * rx * rz],
-            [2 * ry * rx, 3 * ry * ry - 1.0, 2 * ry * rz],
-            [2 * rz * rx, 2 * rz * ry, 3 * rz * rz - 1.0],
+            [3 * rx * rx - 1.0, 3 * rx * ry, 3 * rx * rz],
+            [3 * ry * rx, 3 * ry * ry - 1.0, 3 * ry * rz],
+            [3 * rz * rx, 3 * rz * ry, 3 * rz * rz - 1.0],
         ]
     )
     np.testing.assert_almost_equal(np.linalg.eigvals(mat), [2.0, -1.0, -1.0])

--- a/tests/radpy.py
+++ b/tests/radpy.py
@@ -181,7 +181,7 @@ def HamiltonianZeeman3D(spins, B, theta=0, phi=0, gamma=1.76e8):
 
 
 def HamiltonianHyperfine(spins, pos, pos2, HFC, gamma_mT):
-    omega = HFC * gamma_mT
+    omega = HFC * abs(gamma_mT)
     particles = prodop(pos, pos2, spins)
     return omega * particles
 
@@ -200,7 +200,7 @@ def ExchangeInteraction(r, model="solution"):
 
 
 def HamiltonianExchange(spins, J, gamma=1.76e8):
-    Jcoupling = gamma * J
+    Jcoupling = -abs(gamma) * J
     SASB = prodop(0, 1, spins)
     return Jcoupling * ((2 * SASB) + (0.5 * np.eye(len(SASB))))
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -28,7 +28,7 @@ MEASURE_TIME = False
 PARAMS = dict(
     B=np.random.uniform(size=20),
     J=np.random.uniform(),
-    D=np.random.uniform(),
+    D=-abs(np.random.uniform()),
 )
 
 RADICAL_PAIR = [
@@ -209,9 +209,7 @@ class HilbertTests(unittest.TestCase):
                 for ni, ei in enumerate(couplings)
             ]
         )
-        assert np.all(
-            self.sim.hyperfine_hamiltonian() == HH_true
-        ), "Hyperfine Hamiltonian not calculated properly."
+        np.testing.assert_almost_equal(HH_true, self.sim.hyperfine_hamiltonian())
 
     def test_HE(self):
         HE_true = radpy.HamiltonianExchange(
@@ -222,7 +220,7 @@ class HilbertTests(unittest.TestCase):
 
     def test_HD(self):
         HD_true = radpy.HamiltonianDipolar(
-            len(self.sim.particles), PARAMS["D"], self.gamma_mT
+            len(self.sim.particles), PARAMS["D"], abs(self.gamma_mT)
         )
         HD = self.sim.dipolar_hamiltonian(PARAMS["D"])
         np.testing.assert_almost_equal(HD, HD_true)


### PR DESCRIPTION
Since the sign of hypterfine term was flipped, I have changed the factor `gamma_mT` to `abs(gamma_mT)` in order to avoid confusion. Now total Hamiltonian consists of following from,

<img width="356" height="213" alt="image" src="https://github.com/user-attachments/assets/54a1e7e2-8c00-4974-abb8-1709dff31c7d" />

**The simulation with nonzero `J` and `D` will return the different result from previous version**

The dipolar term `D` should be given by this equaion.
<img width="452" height="181" alt="image" src="https://github.com/user-attachments/assets/dcc9173c-e12a-4d35-b18d-d33dc86ffeeb" />
The scalar `D`, which is multiplied with `2/3*diag([-1, -1, 2])`, should be nagative under point dipole approximation.